### PR TITLE
bug: trace_id/span_id mangling on json-otlp log ingest (#129)

### DIFF
--- a/backend/app/controllers/otelcontrollers/logs_converter.go
+++ b/backend/app/controllers/otelcontrollers/logs_converter.go
@@ -60,12 +60,21 @@ func toLogRecord(
 		severityText = severityTextFromNumber(severityNumber)
 	}
 
+	// JSON-OTLP trace_id/span_id arrive as 24/12 base64 bytes — round-trip through the UUID helpers.
+	var traceIDHex, spanIDHex string
+	if u := otelTraceIDToUUID(lr.TraceId); u != uuid.Nil {
+		traceIDHex = hex.EncodeToString(u[:])
+	}
+	if u := otelSpanIDToUUID(lr.SpanId); u != uuid.Nil {
+		spanIDHex = spanUUIDToHex(u)
+	}
+
 	return models.LogRecord{
 		Id:                 uuid.New(),
 		ProjectId:          projectId,
 		Timestamp:          nanoToTime(ts),
-		TraceId:            hex.EncodeToString(lr.TraceId),
-		SpanId:             hex.EncodeToString(lr.SpanId),
+		TraceId:            traceIDHex,
+		SpanId:             spanIDHex,
 		TraceFlags:         uint8(lr.Flags),
 		SeverityText:       severityText,
 		SeverityNumber:     severityNumber,

--- a/backend/app/controllers/otelcontrollers/logs_converter_test.go
+++ b/backend/app/controllers/otelcontrollers/logs_converter_test.go
@@ -1,0 +1,55 @@
+package otelcontrollers
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+)
+
+// Pins the protojson base64-of-hex round-trip — see logs_converter.go.
+func TestToLogRecord_IDEncoding(t *testing.T) {
+	const wireTraceHex = "7b873c7bbf35739e79e1f7b9736739f7"
+	const wireSpanHex = "7dfd3877775ae1bd"
+
+	// protojson decodes bytes-typed fields as base64; hex chars are valid base64.
+	jsonTrace, err := base64.StdEncoding.DecodeString(wireTraceHex)
+	if err != nil || len(jsonTrace) != 24 {
+		t.Fatalf("seed: jsonTrace len=%d err=%v", len(jsonTrace), err)
+	}
+	jsonSpan, err := base64.StdEncoding.DecodeString(wireSpanHex)
+	if err != nil || len(jsonSpan) != 12 {
+		t.Fatalf("seed: jsonSpan len=%d err=%v", len(jsonSpan), err)
+	}
+	binTrace, _ := hex.DecodeString(wireTraceHex)
+	binSpan, _ := hex.DecodeString(wireSpanHex)
+
+	tests := []struct {
+		name       string
+		traceBytes []byte
+		spanBytes  []byte
+		wantTrace  string
+		wantSpan   string
+	}{
+		{"binary OTLP", binTrace, binSpan, wireTraceHex, wireSpanHex},
+		{"JSON OTLP (protojson base64 roundtrip)", jsonTrace, jsonSpan, wireTraceHex, wireSpanHex},
+		{"missing trace context", nil, nil, "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := toLogRecord(
+				testProjectId,
+				&logspb.LogRecord{TraceId: tt.traceBytes, SpanId: tt.spanBytes},
+				"svc", "", nil, "", "scope", "", nil,
+			)
+			if rec.TraceId != tt.wantTrace {
+				t.Errorf("TraceId = %q (len %d), want %q", rec.TraceId, len(rec.TraceId), tt.wantTrace)
+			}
+			if rec.SpanId != tt.wantSpan {
+				t.Errorf("SpanId = %q (len %d), want %q", rec.SpanId, len(rec.SpanId), tt.wantSpan)
+			}
+		})
+	}
+}


### PR DESCRIPTION
 Fixes #129

 ## Summary

  OTel logs ingested via **OTLP/JSON** (PHP, browser, and other non-Go exporters) were stored with 48-char `trace_id` and 24-char `span_id` instead of the canonical 32/16-char hex. The endpoint detail page's
  **Logs** panel filters `trace_id = <32-char hex from endpoint.id>`, so it never matched anything for those projects — even though the same logs were visible on the standalone `/logs` page.

  ## Root cause

  `logs_converter.go` did `hex.EncodeToString(lr.TraceId)` directly. `protojson` decodes OTLP/JSON''s hex `trace_id` field as if it were base64-encoded bytes, producing 24 garbage bytes from a 32-char hex
  string (and 12 from a span ID). `trace_converter.go` already handled this via `otelTraceIDToUUID` / `otelSpanIDToUUID` (`helpers.go:13-50`); the logs converter was missing the same round-trip.

  ## Fix

  Route the trace/span bytes through the existing UUID converters before hex encoding, in `toLogRecord`. Binary OTLP (Go OTel SDK and friends) is unaffected — `otelTraceIDToUUID` returns the same UUID for the
  16-byte case.

  Regression-pinned by `TestToLogRecord_IDEncoding` covering binary OTLP, JSON-OTLP (protojson base64 round-trip), and missing-trace-context inputs.

<img width="1712" height="825" alt="image" src="https://github.com/user-attachments/assets/431474d8-bb84-48c3-aa99-119bd0f089e7" />


  ## Test plan

  - [ ] Rebuild and restart the backend
  - [ ] Fire a JSON-OTLP-instrumented endpoint (e.g. PHP `/traceway/test-tracing`)
  - [ ] Open the endpoint detail page → **Logs** panel populates
  - [ ] Expand a log row → `Trace ID` is 32 chars and equals `endpoint.id` with dashes removed, lowercased
  - [ ] Existing binary-OTLP projects (Go OTel SDK) still work — log trace IDs unchanged