### PR TITLE
Fix time range preset selection closing

### DIFF
--- a/frontend/src/lib/components/ui/time-range-picker/time-range-picker.svelte
+++ b/frontend/src/lib/components/ui/time-range-picker/time-range-picker.svelte
@@ -243,7 +243,6 @@
         const fromParts = luxonToCalendarDateTime(fromDt);
         const toParts = luxonToCalendarDateTime(now);
 
-        // Update temp values only - don't close or apply yet
         tempFromDateTime = new CalendarDateTime(
             fromParts.year,
             fromParts.month,
@@ -260,6 +259,8 @@
             toParts.minute,
             toParts.second
         );
+
+        applyAndClose();
     }
 
     function toggleCustom() {


### PR DESCRIPTION
## Summary

- Fixes the time range picker so selecting a preset immediately applies the new range and closes the dropdown.
- Keeps the custom date/time flow unchanged: selecting "Set custom" still leaves the picker open so users can choose dates and click Apply.

## Related Issue

Closes #135

## Testing

- Ran `npm run check` in `frontend` after installing dependencies.
- The command currently fails on existing TypeScript errors in `frontend/src/lib/components/issues/session-replay.svelte`, unrelated to this change:
  - `Property 'href' does not exist on type ...`
  - `FlutterVideoEvent[]` is not assignable to `eventWithTime[]`
