### PR TITLE
feat: add Pushover notification channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Traceway is an **OpenTelemetry-native** observability platform that combines **l
 - **Session Replay** — Watch what the user did right before the error. Available for web (any JS framework) and Flutter.
 - **AI Observability** — LLM cost, tokens, latency, and full conversations across providers (OpenRouter and any OTel-compatible AI gateway).
 
-Plus: configurable alerts (Slack / GitHub / email / webhook), Apdex + Impact-Score endpoint ranking, multi-tenant orgs with role-based access, and a per-endpoint slow-threshold override.
+Plus: configurable alerts (Slack / GitHub / email / webhook / Pushover), Apdex + Impact-Score endpoint ranking, multi-tenant orgs with role-based access, and a per-endpoint slow-threshold override.
 
 ## Why Traceway
 

--- a/backend/app/controllers/notification_channel.controller.go
+++ b/backend/app/controllers/notification_channel.controller.go
@@ -43,7 +43,7 @@ type createChannelRequest struct {
 }
 
 var validChannelTypes = map[string]bool{
-	"email": true, "webhook": true, "slack": true, "github": true,
+	"email": true, "webhook": true, "slack": true, "github": true, "pushover": true,
 }
 
 func (ctrl *notificationChannelController) Create(ctx *gin.Context) {
@@ -69,7 +69,7 @@ func (ctrl *notificationChannelController) Create(ctx *gin.Context) {
 		return
 	}
 	if !validChannelTypes[req.ChannelType] {
-		ctx.JSON(http.StatusUnprocessableEntity, gin.H{"error": "Channel type must be one of: email, webhook, slack, github."})
+		ctx.JSON(http.StatusUnprocessableEntity, gin.H{"error": "Channel type must be one of: email, webhook, slack, github, pushover."})
 		return
 	}
 
@@ -142,7 +142,7 @@ func (ctrl *notificationChannelController) Update(ctx *gin.Context) {
 		return
 	}
 	if !validChannelTypes[req.ChannelType] {
-		ctx.JSON(http.StatusUnprocessableEntity, gin.H{"error": "Channel type must be one of: email, webhook, slack, github."})
+		ctx.JSON(http.StatusUnprocessableEntity, gin.H{"error": "Channel type must be one of: email, webhook, slack, github, pushover."})
 		return
 	}
 

--- a/backend/app/notifications/adapter_pushover.go
+++ b/backend/app/notifications/adapter_pushover.go
@@ -1,0 +1,141 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type PushoverAdapter struct {
+	UserKey  string `json:"userKey"`
+	AppToken string `json:"appToken"`
+	Device   string `json:"device,omitempty"`
+	Priority int    `json:"priority,omitempty"`
+	Retry    int    `json:"retry,omitempty"`
+	Expire   int    `json:"expire,omitempty"`
+	Sound    string `json:"sound,omitempty"`
+	TTL      int    `json:"ttl,omitempty"`
+	HTML     bool   `json:"html,omitempty"`
+	Callback string `json:"callback,omitempty"`
+}
+
+func (a *PushoverAdapter) Type() string { return "pushover" }
+
+func (a *PushoverAdapter) Validate() error {
+	if a.UserKey == "" {
+		return fmt.Errorf("Pushover user key is required")
+	}
+	if a.AppToken == "" {
+		return fmt.Errorf("Pushover app token is required")
+	}
+	if a.Priority == 2 {
+		if a.Retry < 30 {
+			return fmt.Errorf("Pushover retry must be at least 30 seconds")
+		}
+		if a.Expire < 1 || a.Expire > 10800 {
+			return fmt.Errorf("Pushover expire must be between 1 and 10800 seconds")
+		}
+		if a.Retry >= a.Expire {
+			return fmt.Errorf("Pushover retry (%ds) must be less than expire (%ds)", a.Retry, a.Expire)
+		}
+	}
+	return nil
+}
+
+func (a *PushoverAdapter) Send(ctx context.Context, msg Message) error {
+	form := url.Values{
+		"token":   {a.AppToken},
+		"user":    {a.UserKey},
+		"message": {msg.Body},
+	}
+	if msg.Subject != "" {
+		form.Set("title", msg.Subject)
+	}
+	if a.Device != "" {
+		form.Set("device", a.Device)
+	}
+	if a.Sound != "" {
+		form.Set("sound", a.Sound)
+	}
+	if a.HTML {
+		form.Set("html", "1")
+	}
+	if a.TTL > 0 {
+		form.Set("ttl", strconv.Itoa(a.TTL))
+	}
+	if msg.URL != "" {
+		form.Set("url", msg.URL)
+	}
+	form.Set("timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+
+	priority := a.Priority
+	form.Set("priority", strconv.Itoa(priority))
+
+	if priority == 2 {
+		retry := a.Retry
+		if retry < 30 {
+			retry = 30
+		}
+		expire := a.Expire
+		if expire < 1 {
+			expire = 3600
+		} else if expire > 10800 {
+			expire = 10800
+		}
+		form.Set("retry", strconv.Itoa(retry))
+		form.Set("expire", strconv.Itoa(expire))
+		if a.Callback != "" {
+			form.Set("callback", a.Callback)
+		}
+	}
+
+	body := form.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://api.pushover.net/1/messages.json",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create Pushover request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "Traceway/1.0")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("Pushover request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == http.StatusOK {
+		var result struct {
+			Status  int    `json:"status"`
+			Request string `json:"request"`
+		}
+		if err := json.Unmarshal(respBody, &result); err == nil && result.Status == 1 {
+			return nil
+		}
+		return fmt.Errorf("Pushover returned unexpected response: %s", string(respBody))
+	}
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return fmt.Errorf("Pushover rate limit exceeded (monthly quota exhausted)")
+	}
+
+	var errResult struct {
+		Errors []string `json:"errors"`
+	}
+	if err := json.Unmarshal(respBody, &errResult); err == nil && len(errResult.Errors) > 0 {
+		return fmt.Errorf("Pushover returned %d: %s", resp.StatusCode, strings.Join(errResult.Errors, "; "))
+	}
+
+	return fmt.Errorf("Pushover returned status %d", resp.StatusCode)
+}

--- a/backend/app/notifications/adapters.go
+++ b/backend/app/notifications/adapters.go
@@ -57,6 +57,12 @@ func NewAdapter(channelType string, configJSON json.RawMessage) (Adapter, error)
 			return nil, fmt.Errorf("invalid github config: %w", err)
 		}
 		return &cfg, nil
+	case "pushover":
+		var cfg PushoverAdapter
+		if err := json.Unmarshal(configJSON, &cfg); err != nil {
+			return nil, fmt.Errorf("invalid pushover config: %w", err)
+		}
+		return &cfg, nil
 	default:
 		return nil, fmt.Errorf("unknown channel type: %s", channelType)
 	}

--- a/docs/pages/learn/alerts.mdx
+++ b/docs/pages/learn/alerts.mdx
@@ -1,12 +1,12 @@
 # Alerts
 
-Alerts notify you when conditions in your application require attention — errors, latency spikes, metric thresholds, or missing data. Configure channels and rules to get notified through email, Slack, webhooks, or GitHub Issues.
+Alerts notify you when conditions in your application require attention — errors, latency spikes, metric thresholds, or missing data. Configure channels and rules to get notified through email, Slack, webhooks, GitHub Issues, or Pushover.
 
 ## How Alerts Work
 
 The alerting system has two parts:
 
-- **Channels** define where notifications are delivered (email, Slack, webhook, GitHub)
+- **Channels** define where notifications are delivered (email, Slack, webhook, GitHub, Pushover)
 - **Rules** define what conditions trigger a notification
 
 When a rule's condition is met, Traceway sends a notification through the rule's attached channel. Each rule is linked to exactly one channel, but a channel can be used by multiple rules.
@@ -21,6 +21,7 @@ A channel represents a notification destination. Traceway supports four channel 
 | Slack   | Posts a message to a Slack channel via incoming webhook | Webhook URL |
 | Webhook | Sends an HTTP POST with a JSON payload to any URL | URL, optional headers, optional HMAC secret |
 | GitHub  | Creates a GitHub issue in a repository | Personal access token, repository owner/name, optional labels |
+| Pushover | Sends push notifications to your mobile devices | User Key, App Token |
 
 Each channel has a **Test** button that sends a sample notification so you can verify the configuration before attaching rules.
 

--- a/frontend/src/routes/notifications/+page.svelte
+++ b/frontend/src/routes/notifications/+page.svelte
@@ -97,12 +97,13 @@
 		email: 'Email',
 		webhook: 'Webhook',
 		slack: 'Slack',
-		github: 'GitHub'
+		github: 'GitHub',
+		pushover: 'Pushover'
 	};
 
 	const tabDescriptions: Record<string, string> = {
 		channels:
-			'Channels define where your notifications are delivered — such as Email, Slack, Webhooks, or GitHub Issues. Create a channel first, then attach it to a rule.',
+			'Channels define where your notifications are delivered — such as Email, Slack, Webhooks, GitHub Issues, or Pushover. Create a channel first, then attach it to a rule.',
 		rules: 'Rules define when notifications are triggered. Each rule monitors a specific condition and sends an alert through the attached channel when that condition is met.',
 		history:
 			'A log of all notifications that have been sent, including their status and the rule that triggered them.'

--- a/frontend/src/routes/notifications/channel-dialog.svelte
+++ b/frontend/src/routes/notifications/channel-dialog.svelte
@@ -44,6 +44,16 @@
 	let githubOwner = $state('');
 	let githubRepo = $state('');
 	let githubLabels = $state('');
+	let pushoverUserKey = $state('');
+	let pushoverAppToken = $state('');
+	let pushoverDevice = $state('');
+	let pushoverPriority = $state(0);
+	let pushoverRetry = $state(30);
+	let pushoverExpire = $state(3600);
+	let pushoverCallback = $state('');
+	let pushoverSound = $state('');
+	let pushoverHtml = $state(false);
+	let pushoverTtl = $state(0);
 
 	const isEditing = $derived(channel !== null);
 
@@ -51,7 +61,8 @@
 		{ value: 'email', label: 'Email' },
 		{ value: 'webhook', label: 'Webhook' },
 		{ value: 'slack', label: 'Slack' },
-		{ value: 'github', label: 'GitHub' }
+		{ value: 'github', label: 'GitHub' },
+		{ value: 'pushover', label: 'Pushover' }
 	];
 
 	function resetForm() {
@@ -70,6 +81,16 @@
 		githubOwner = '';
 		githubRepo = '';
 		githubLabels = '';
+		pushoverUserKey = '';
+		pushoverAppToken = '';
+		pushoverDevice = '';
+		pushoverPriority = 0;
+		pushoverRetry = 30;
+		pushoverExpire = 3600;
+		pushoverCallback = '';
+		pushoverSound = '';
+		pushoverHtml = false;
+		pushoverTtl = 0;
 	}
 
 	function populateFromChannel(ch: NotificationChannel) {
@@ -98,6 +119,17 @@
 			githubOwner = config.owner || '';
 			githubRepo = config.repo || '';
 			githubLabels = (config.labels || []).join(', ');
+		} else if (ch.channelType === 'pushover') {
+			pushoverUserKey = config.userKey || '';
+			pushoverAppToken = config.appToken || '';
+			pushoverDevice = config.device || '';
+			pushoverPriority = config.priority ?? 0;
+			pushoverRetry = config.retry ?? 30;
+			pushoverExpire = config.expire ?? 3600;
+			pushoverCallback = config.callback || '';
+			pushoverSound = config.sound || '';
+			pushoverHtml = config.html ?? false;
+			pushoverTtl = config.ttl ?? 0;
 		}
 	}
 
@@ -130,6 +162,22 @@
 				.map((l) => l.trim())
 				.filter((l) => l);
 			if (labels.length > 0) config.labels = labels;
+			return config;
+		} else if (channelType === 'pushover') {
+			const config: any = {
+				userKey: pushoverUserKey,
+				appToken: pushoverAppToken
+			};
+			if (pushoverDevice) config.device = pushoverDevice;
+			if (pushoverPriority) config.priority = pushoverPriority;
+			if (pushoverPriority === 2) {
+				config.retry = pushoverRetry;
+				config.expire = pushoverExpire;
+				if (pushoverCallback) config.callback = pushoverCallback;
+			}
+			if (pushoverSound) config.sound = pushoverSound;
+			if (pushoverHtml) config.html = pushoverHtml;
+			if (pushoverTtl > 0) config.ttl = pushoverTtl;
 			return config;
 		}
 		return {};
@@ -203,7 +251,7 @@
 </script>
 
 <AlertDialog.Root {open} onOpenChange={handleOpenChange}>
-	<AlertDialog.Content class="max-w-md">
+	<AlertDialog.Content class="max-w-md max-h-[90vh] overflow-y-auto">
 		<AlertDialog.Header>
 			<AlertDialog.Title>{isEditing ? 'Edit Channel' : 'New Channel'}</AlertDialog.Title>
 			<AlertDialog.Description>
@@ -374,6 +422,58 @@
 				<div class="space-y-2">
 					<Label for="gh-labels">Labels (optional, comma-separated)</Label>
 					<Input id="gh-labels" bind:value={githubLabels} placeholder="bug, traceway" />
+				</div>
+			{:else if channelType === 'pushover'}
+				<div class="space-y-2">
+					<Label for="po-user-key">User Key</Label>
+					<Input id="po-user-key" bind:value={pushoverUserKey} placeholder="Your Pushover user key" required />
+				</div>
+				<div class="space-y-2">
+					<Label for="po-app-token">App Token</Label>
+					<Input id="po-app-token" type="password" bind:value={pushoverAppToken} placeholder="Your Pushover application token" required />
+				</div>
+				<div class="space-y-2">
+					<Label for="po-device">Device (optional)</Label>
+					<Input id="po-device" bind:value={pushoverDevice} placeholder="Leave empty for all devices" />
+				</div>
+				<div class="space-y-2">
+					<Label for="po-priority">Priority</Label>
+					<Select.Root type="single" bind:value={pushoverPriority}>
+						<Select.Trigger class="w-full">
+							{pushoverPriority === 0 ? 'Normal' : pushoverPriority === 1 ? 'High' : 'Emergency'}
+						</Select.Trigger>
+						<Select.Content>
+							<Select.Item value={0}>Normal</Select.Item>
+							<Select.Item value={1}>High</Select.Item>
+							<Select.Item value={2}>Emergency</Select.Item>
+						</Select.Content>
+					</Select.Root>
+				</div>
+				{#if pushoverPriority === 2}
+					<div class="space-y-2">
+						<Label for="po-retry">Retry Interval (seconds, min 30)</Label>
+						<Input id="po-retry" type="number" bind:value={pushoverRetry} min={30} />
+					</div>
+					<div class="space-y-2">
+						<Label for="po-expire">Expiry (seconds, max 10800)</Label>
+						<Input id="po-expire" type="number" bind:value={pushoverExpire} min={1} max={10800} />
+					</div>
+					<div class="space-y-2">
+						<Label for="po-callback">Callback URL (optional)</Label>
+						<Input id="po-callback" bind:value={pushoverCallback} placeholder="https://hooks.example.com/acknowledged" />
+					</div>
+				{/if}
+				<div class="space-y-2">
+					<Label for="po-sound">Sound (optional)</Label>
+					<Input id="po-sound" bind:value={pushoverSound} placeholder="e.g. pushover, bike, bugle" />
+				</div>
+				<div class="flex items-center gap-2">
+					<input id="po-html" type="checkbox" bind:checked={pushoverHtml} class="h-4 w-4" />
+					<Label for="po-html">Enable HTML formatting</Label>
+				</div>
+				<div class="space-y-2">
+					<Label for="po-ttl">Time to Live (seconds, 0 = forever)</Label>
+					<Input id="po-ttl" type="number" bind:value={pushoverTtl} min={0} placeholder="0" />
 				</div>
 			{/if}
 

--- a/website/app/product/performance/page.tsx
+++ b/website/app/product/performance/page.tsx
@@ -226,7 +226,7 @@ export default function PerformancePage() {
                       <p>
                         For incident management, notification rules fire when
                         the Impact Score or error rate crosses a threshold, and
-                        route alerts to Slack, GitHub Issues, email, or custom
+                        route alerts to Slack, GitHub Issues, email, Pushover, or custom
                         webhooks.
                       </p>
                     </>


### PR DESCRIPTION
Adds Pushover as a new notification channel type. Supports user key + app token authentication, priority levels (normal/high/emergency), device targeting, custom sound, HTML formatting, TTL, and emergency retry/expire/callback fields.

Backend: adapter_pushover.go follows the existing Adapter interface.
Frontend: channel config form with conditionally revealed emergency fields.
Tested against live Pushover API across all priority levels.