### PR TITLE
feat: add project rename, recategorization, and deletion

### DIFF
--- a/backend/app/cache/project_cache.go
+++ b/backend/app/cache/project_cache.go
@@ -97,6 +97,31 @@ func (c *projectCache) AddProject(proj *models.Project) {
 	}
 }
 
+func (c *projectCache) UpdateProject(proj *models.Project) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cached, ok := c.projectsById[proj.Id]
+	if !ok {
+		return
+	}
+	cached.Name = proj.Name
+	cached.Framework = proj.Framework
+}
+
+func (c *projectCache) RemoveProject(id uuid.UUID) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	proj, ok := c.projectsById[id]
+	if !ok {
+		return
+	}
+	delete(c.projects, proj.Token)
+	delete(c.projectsById, id)
+	if proj.SourceMapToken != nil {
+		delete(c.projectsBySourceMapToken, *proj.SourceMapToken)
+	}
+}
+
 func (c *projectCache) GetBySourceMapToken(token string) *models.Project {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/backend/app/controllers/project.controller.go
+++ b/backend/app/controllers/project.controller.go
@@ -56,6 +56,11 @@ type CreateProjectRequest struct {
 	Framework string `json:"framework" binding:"required"`
 }
 
+type UpdateProjectRequest struct {
+	Name      string `json:"name" binding:"required"`
+	Framework string `json:"framework" binding:"required"`
+}
+
 func (p projectController) ListProjects(c *gin.Context) {
 	userId := middleware.GetUserId(c)
 
@@ -119,6 +124,63 @@ func (p projectController) CreateProject(c *gin.Context) {
 	cache.ProjectCache.AddProject(project)
 
 	c.JSON(http.StatusCreated, project.ToProjectWithBackendUrl())
+}
+
+func (p projectController) UpdateProject(c *gin.Context) {
+	var request UpdateProjectRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	nameLen := utf8.RuneCountInString(request.Name)
+	if nameLen < 1 || nameLen > 100 {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "Project name must be between 1 and 100 characters"})
+		return
+	}
+	if !projectNameRegex.MatchString(request.Name) {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "Project name can only contain letters, numbers, spaces, hyphens, and underscores"})
+		return
+	}
+	if !validFrameworks[request.Framework] {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "Framework must be one of: gin, fiber, chi, fasthttp, stdlib, custom, react, svelte, vuejs, jquery, react-native, hono, cloudflare, opentelemetry, symfony, laravel, flutter, android"})
+		return
+	}
+
+	projectId, err := middleware.GetProjectId(c)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("RequireProjectAccess middleware must be applied: %w", err))
+		return
+	}
+
+	tx := middleware.GetTx(c)
+	project, err := repositories.ProjectRepository.Update(tx, projectId, request.Name, request.Framework)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("error updating project: %w", err))
+		return
+	}
+
+	cache.ProjectCache.UpdateProject(project)
+
+	c.JSON(http.StatusOK, project.ToProjectWithBackendUrl())
+}
+
+func (p projectController) DeleteProject(c *gin.Context) {
+	projectId, err := middleware.GetProjectId(c)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("RequireProjectAccess middleware must be applied: %w", err))
+		return
+	}
+
+	tx := middleware.GetTx(c)
+	if err := repositories.ProjectRepository.Delete(tx, projectId); err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("error deleting project: %w", err))
+		return
+	}
+
+	cache.ProjectCache.RemoveProject(projectId)
+
+	c.JSON(http.StatusOK, gin.H{})
 }
 
 func (p projectController) GenerateSourceMapToken(c *gin.Context) {

--- a/backend/app/controllers/routes.go
+++ b/backend/app/controllers/routes.go
@@ -41,6 +41,8 @@ func RegisterControllers(router *gin.RouterGroup) {
 	// Project management
 	router.GET("/projects", middleware.UseAppAuth, ProjectController.ListProjects)
 	router.POST("/projects", middleware.UseAppAuth, middleware.RequireProjectAccess, middleware.RequireWriteAccess, ProjectController.CreateProject)
+	router.PUT("/projects", middleware.UseAppAuth, middleware.RequireProjectAccess, middleware.RequireWriteAccess, middleware.Transactional, ProjectController.UpdateProject)
+	router.DELETE("/projects", middleware.UseAppAuth, middleware.RequireProjectAccess, middleware.RequireWriteAccess, middleware.Transactional, ProjectController.DeleteProject)
 
 	// Dashboard endpoints (projectId in query param)
 	router.POST("/stats", middleware.UseAppAuth, middleware.RequireProjectAccess, MetricRecordController.FindHomepageStats)

--- a/backend/app/repositories/project.repository.go
+++ b/backend/app/repositories/project.repository.go
@@ -184,6 +184,40 @@ func (p *projectRepository) GenerateSourceMapToken(tx *sql.Tx, projectId uuid.UU
 	return token, nil
 }
 
+func (p *projectRepository) Update(tx *sql.Tx, id uuid.UUID, name string, framework string) (*models.Project, error) {
+	project, err := p.FindById(tx, id)
+	if err != nil {
+		return nil, err
+	}
+	if project == nil {
+		return nil, fmt.Errorf("project not found: %s", id)
+	}
+	project.Name = name
+	project.Framework = framework
+	err = lit.UpdateNamed[models.Project](tx, project, "id = :id", lit.P{"id": id})
+	if err != nil {
+		return nil, err
+	}
+	return project, nil
+}
+
+func (p *projectRepository) Delete(tx *sql.Tx, id uuid.UUID) error {
+	related := []string{
+		"notification_history",
+		"notification_rules",
+		"notification_channels",
+		"widget_groups",
+		"source_maps",
+		"metric_registry",
+	}
+	for _, table := range related {
+		if err := lit.Delete(tx, "DELETE FROM "+table+" WHERE project_id = $1", id); err != nil {
+			return fmt.Errorf("deleting %s: %w", table, err)
+		}
+	}
+	return lit.Delete(tx, "DELETE FROM projects WHERE id = $1", id)
+}
+
 func (p *projectRepository) FindBySourceMapToken(tx *sql.Tx, token string) (*models.Project, error) {
 	return lit.SelectSingleNamed[models.Project](
 		tx,

--- a/frontend/src/lib/components/edit-project-modal.svelte
+++ b/frontend/src/lib/components/edit-project-modal.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+    import * as Sheet from "$lib/components/ui/sheet";
+    import * as AlertDialog from "$lib/components/ui/alert-dialog";
+    import { Button } from "$lib/components/ui/button";
+    import { Input } from "$lib/components/ui/input";
+    import { Label } from "$lib/components/ui/label";
+    import { projectsState, type Project, type Framework } from '$lib/state/projects.svelte';
+    import { Check, Trash2 } from 'lucide-svelte';
+    import FrameworkCombobox from './framework-combobox.svelte';
+    import { toast } from 'svelte-sonner';
+    import { goto } from '$app/navigation';
+
+    interface Props {
+        open: boolean;
+        onOpenChange: (open: boolean) => void;
+        project: Project | null;
+    }
+
+    let { open, onOpenChange, project }: Props = $props();
+
+    let projectName = $state('');
+    let selectedFramework = $state<Framework>('gin');
+    let loading = $state(false);
+    let error = $state('');
+    let showDeleteConfirm = $state(false);
+    let deleting = $state(false);
+
+    $effect(() => {
+        if (open && project) {
+            projectName = project.name;
+            selectedFramework = project.framework;
+            error = '';
+        }
+    });
+
+    async function handleSubmit(e: Event) {
+        e.preventDefault();
+        if (!projectName.trim()) {
+            error = 'Project name is required';
+            return;
+        }
+        if (!project) return;
+
+        loading = true;
+        error = '';
+
+        try {
+            await projectsState.updateProject(project.id, projectName.trim(), selectedFramework);
+            toast.success('Successfully updated the project', { position: 'top-center' });
+            onOpenChange(false);
+        } catch (err: any) {
+            error = err instanceof Error ? err.message : 'Failed to update project';
+        } finally {
+            loading = false;
+        }
+    }
+
+    async function handleDelete() {
+        if (!project) return;
+
+        deleting = true;
+        try {
+            await projectsState.deleteProject(project.id);
+            toast.success('Successfully deleted the project', { position: 'top-center' });
+            showDeleteConfirm = false;
+            onOpenChange(false);
+            goto('/');
+        } catch (err: any) {
+            toast.error(err instanceof Error ? err.message : 'Failed to delete project', { position: 'top-center' });
+        } finally {
+            deleting = false;
+        }
+    }
+
+    function handleClose() {
+        error = '';
+        showDeleteConfirm = false;
+        onOpenChange(false);
+    }
+</script>
+
+<Sheet.Root {open} onOpenChange={handleClose}>
+    <Sheet.Content side="right" class="w-[400px] sm:w-[540px]">
+        <Sheet.Header>
+            <Sheet.Title>Edit Project</Sheet.Title>
+            <Sheet.Description>
+                Update your project name or framework.
+            </Sheet.Description>
+        </Sheet.Header>
+
+        <form onsubmit={handleSubmit} class="px-6 py-6 space-y-5">
+            <div class="space-y-2">
+                <Label for="edit-project-name">Project Name</Label>
+                <Input
+                    id="edit-project-name"
+                    type="text"
+                    placeholder="My Application"
+                    bind:value={projectName}
+                    disabled={loading}
+                />
+                <p class="text-xs text-muted-foreground">
+                    A unique name for your project (letters, numbers, spaces, hyphens)
+                </p>
+            </div>
+
+            <div class="space-y-2">
+                <Label for="edit-framework">Framework</Label>
+                <FrameworkCombobox bind:value={selectedFramework} disabled={loading} />
+                <p class="text-xs text-muted-foreground">
+                    Select your framework for tailored integration code
+                </p>
+            </div>
+
+            {#if error}
+                <div class="rounded-md bg-destructive/10 border border-destructive/20 p-3">
+                    <p class="text-sm text-destructive">{error}</p>
+                </div>
+            {/if}
+
+            <div class="flex justify-end gap-2 pt-2">
+                <Button type="button" variant="outline" onclick={handleClose} disabled={loading}>
+                    Cancel
+                </Button>
+                <Button type="submit" disabled={loading}>
+                    {#if loading}
+                        Updating...
+                    {:else}
+                        <Check class="mr-2 h-4 w-4" />
+                        Update Project
+                    {/if}
+                </Button>
+            </div>
+        </form>
+
+        <div class="px-6 pb-6">
+            <div class="border-t pt-6">
+                <p class="text-sm text-muted-foreground mb-3">Danger zone</p>
+                <Button
+                    type="button"
+                    variant="outline"
+                    class="border-destructive text-destructive hover:bg-destructive hover:text-destructive-foreground"
+                    onclick={() => showDeleteConfirm = true}
+                >
+                    <Trash2 class="mr-2 h-4 w-4" />
+                    Delete Project
+                </Button>
+            </div>
+        </div>
+    </Sheet.Content>
+</Sheet.Root>
+
+<AlertDialog.Root bind:open={showDeleteConfirm}>
+    <AlertDialog.Content interactOutsideBehavior="close">
+        <AlertDialog.Header>
+            <AlertDialog.Title>Delete Project</AlertDialog.Title>
+            <AlertDialog.Description>
+                Are you sure you want to delete this project? This action cannot be undone and all associated data will become inaccessible.
+            </AlertDialog.Description>
+        </AlertDialog.Header>
+        <div class="rounded-md border px-4 py-3 mx-6">
+            <p class="text-sm font-semibold">{project?.name}</p>
+        </div>
+        <AlertDialog.Footer>
+            <Button variant="outline" onclick={() => showDeleteConfirm = false} disabled={deleting}>
+                Cancel
+            </Button>
+            <Button variant="destructive" onclick={handleDelete} disabled={deleting}>
+                {deleting ? 'Deleting...' : 'Delete Project'}
+            </Button>
+        </AlertDialog.Footer>
+    </AlertDialog.Content>
+</AlertDialog.Root>

--- a/frontend/src/lib/state/projects.svelte.ts
+++ b/frontend/src/lib/state/projects.svelte.ts
@@ -148,6 +148,19 @@ class ProjectsState {
         return response;
     }
 
+    async updateProject(id: string, name: string, framework: Framework): Promise<Project> {
+        const response = await api.put('/projects', { name, framework }, {
+            projectId: id
+        });
+        await this.loadProjects();
+        return response;
+    }
+
+    async deleteProject(id: string): Promise<void> {
+        await api.delete('/projects', { projectId: id });
+        await this.loadProjects();
+    }
+
     async generateSourceMapToken(): Promise<string> {
         const resp = await api.post('/projects/source-map-token', {}, {
             projectId: this.currentProjectId ?? undefined

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -7,10 +7,11 @@
 	import { incrementNavDepth, decrementNavDepth } from '$lib/utils/back-navigation';
 	import AppSidebar from '$lib/components/app-sidebar.svelte';
 	import AddProjectModal from '$lib/components/add-project-modal.svelte';
+	import EditProjectModal from '$lib/components/edit-project-modal.svelte';
 	import FrameworkIcon from '$lib/components/framework-icon.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar';
 	import { Button } from '$lib/components/ui/button';
-	import { Sun, Moon, LogOut, Plus, Check } from '@lucide/svelte';
+	import { Sun, Moon, LogOut, Plus, Check, Pencil } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 	import { ChevronDown } from 'lucide-svelte';
@@ -28,6 +29,7 @@
 
 	let { children } = $props();
 	let showAddProjectModal = $state(false);
+	let showEditProjectModal = $state(false);
 
 	// Track navigation depth for smart back buttons
 	let lastPathname = '';
@@ -131,6 +133,12 @@
 									<DropdownMenu.Item disabled>No projects yet</DropdownMenu.Item>
 								{/if}
 								<DropdownMenu.Separator />
+								{#if projectsState.canManageCurrentProject}
+									<DropdownMenu.Item onclick={() => showEditProjectModal = true} class="cursor-pointer">
+										<Pencil class="mr-2 h-4 w-4" />
+										Edit Project
+									</DropdownMenu.Item>
+								{/if}
 								<DropdownMenu.Item onclick={handleAddProjectClick} class="cursor-pointer">
 									<Plus class="mr-2 h-4 w-4" />
 									Add Project
@@ -167,6 +175,12 @@
 		open={showAddProjectModal}
 		onOpenChange={(open) => (showAddProjectModal = open)}
 		onProjectCreated={handleProjectCreated}
+	/>
+
+	<EditProjectModal
+		open={showEditProjectModal}
+		onOpenChange={(open) => (showEditProjectModal = open)}
+		project={projectsState.currentProject}
 	/>
 
 	<Toaster position="bottom-right" />


### PR DESCRIPTION
Users can now edit a project's name and framework after creation via a new "Edit Project" option in the project dropdown. The slide-out panel pre-fills the current values and validates input server-side.

A delete action is included in the same panel behind an AlertDialog confirmation that prominently displays the project name before proceeding. Deletion cascades through all dependent PostgreSQL rows (notification history/rules/channels, widget groups, source maps, metric registry) within a single transaction.

<img width="369" height="572" alt="image" src="https://github.com/user-attachments/assets/594ae30b-04de-470a-916a-a6faa6d61363" />
<img width="538" height="260" alt="image" src="https://github.com/user-attachments/assets/9eafe10c-f5dc-45c8-a168-6419812717e0" />
