### PR TITLE
Add Claude Code plugin manifests and fix traceway skill frontmatter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "traceway",
+  "owner": {
+    "name": "Traceway"
+  },
+  "description": "Official Traceway plugin marketplace",
+  "plugins": [
+    {
+      "name": "tw",
+      "source": "./",
+      "description": "Traceway skills: /tw:traceway debugs production issues through the traceway CLI, /tw:traceway-setup instruments a project to report to a Traceway instance."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "tw",
+  "description": "Traceway skills: /tw:traceway debugs production issues through the traceway CLI, /tw:traceway-setup instruments a project to report to a Traceway instance.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Traceway"
+  },
+  "homepage": "https://tracewayapp.com",
+  "repository": "https://github.com/tracewayapp/traceway",
+  "license": "MIT"
+}

--- a/skills/traceway/SKILL.md
+++ b/skills/traceway/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: traceway
-description: Operate a Traceway observability instance through the traceway CLI: log in, query exceptions, logs, endpoints, and metrics, and debug production issues down to root cause. Use when the user invokes /traceway with a subcommand, e.g. "/traceway login", "/traceway debug issue <hash|url|title>", "/traceway what's broken in prod", or whenever they want to investigate errors, crashes, slowness, or logs from an app monitored by Traceway.
+description: 'Operate a Traceway observability instance through the traceway CLI: log in, query exceptions, logs, endpoints, and metrics, and debug production issues down to root cause. Use when the user invokes /traceway with a subcommand, e.g. "/traceway login", "/traceway debug issue <hash|url|title>", "/traceway what''s broken in prod", or whenever they want to investigate errors, crashes, slowness, or logs from an app monitored by Traceway.'
 ---
 
 # Traceway


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/plugin.json` (plugin `tw`) and `.claude-plugin/marketplace.json` (marketplace `traceway`) so the repo is installable as a Claude Code plugin: `/plugin marketplace add tracewayapp/traceway` then `/plugin install tw@traceway`, giving `/tw:traceway` and `/tw:traceway-setup`.
- Fix invalid YAML frontmatter in `skills/traceway/SKILL.md`: the unquoted `: ` in the description made strict parsers reject the skill, so `npx skills add tracewayapp/traceway` installed only `traceway-setup`. The description is now quoted.

## Verification
- `claude plugin validate .` passes.
- `npx skills add <repo> --list` now reports "Found 2 skills" (`traceway`, `traceway-setup`); before the fix it found 1. Names and install behavior for `npx skills` users are unchanged: the skills CLI reads names only from SKILL.md frontmatter and ignores the plugin namespace (no `skills` array declared in the manifests, so picker grouping is also unchanged).