### PR TITLE
feat(profiling): native pprof ingest + query API (PR 3)

### DIFF
--- a/backend/app/controllers/clientcontrollers/profile_ingest.controller.go
+++ b/backend/app/controllers/clientcontrollers/profile_ingest.controller.go
@@ -1,0 +1,102 @@
+package clientcontrollers
+
+import (
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tracewayapp/traceway/backend/app/hooks"
+	"github.com/tracewayapp/traceway/backend/app/middleware"
+	"github.com/tracewayapp/traceway/backend/app/models"
+	"github.com/tracewayapp/traceway/backend/app/monitoring"
+	"github.com/tracewayapp/traceway/backend/app/profiling"
+	"github.com/tracewayapp/traceway/backend/app/repositories"
+	traceway "go.tracewayapp.com"
+)
+
+type profileIngestController struct{}
+
+func (e profileIngestController) Ingest(c *gin.Context) {
+	monitoring.IngestStarted()
+	defer monitoring.IngestFinished()
+
+	projectId, err := middleware.GetProjectId(c)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("UseClientAuth middleware must be applied: %w", err))
+		return
+	}
+
+	var project *models.Project
+	if projectAsAny, exists := c.Get(middleware.ProjectContextKey); exists {
+		if p, ok := projectAsAny.(*models.Project); ok {
+			project = p
+		}
+	}
+
+	if project != nil && project.OrganizationId != nil {
+		if !hooks.CanReport(*project.OrganizationId) {
+			monitoring.RecordRateLimited(*project.OrganizationId)
+			c.AbortWithStatus(http.StatusTooManyRequests)
+			return
+		}
+	}
+
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read request body"})
+		return
+	}
+
+	serviceName := c.Query("service")
+	if serviceName == "" && project != nil {
+		serviceName = project.Name
+	}
+
+	ingestCtx := profiling.IngestContext{
+		ProjectId:          projectId,
+		DefaultServiceName: serviceName,
+		ServerName:         c.Query("serverName"),
+		AppVersion:         c.Query("appVersion"),
+		ReceivedAt:         time.Now().UTC(),
+	}
+
+	decoded, err := (profiling.PprofDecoder{}).Decode(ingestCtx, body)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	convertStart := time.Now()
+	var stacks []models.ProfileStack
+	var samples []models.ProfileSample
+	var profiles []models.Profile
+	for _, d := range decoded {
+		s, sm, p := profiling.BuildRows(d, projectId)
+		stacks = append(stacks, s...)
+		samples = append(samples, sm...)
+		profiles = append(profiles, p...)
+	}
+	convertMs := float64(time.Since(convertStart).Microseconds()) / 1000.0
+
+	insertStart := time.Now()
+	if err := repositories.ProfileRepository.InsertStacksAsync(c, stacks); err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("error inserting profiling stacks: %w", err))
+		return
+	}
+	if err := repositories.ProfileRepository.InsertSamplesAsync(c, samples); err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("error inserting profiling samples: %w", err))
+		return
+	}
+	if err := repositories.ProfileRepository.InsertProfilesAsync(c, profiles); err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("error inserting profiles: %w", err))
+		return
+	}
+	insertMs := float64(time.Since(insertStart).Microseconds()) / 1000.0
+
+	monitoring.RecordIngestBatch(monitoring.SignalNative, "profiles", convertMs, insertMs, len(samples), len(body))
+
+	c.JSON(http.StatusOK, gin.H{})
+}
+
+var ProfileIngestController = profileIngestController{}

--- a/backend/app/controllers/clientcontrollers/profile_ingest_controller_test.go
+++ b/backend/app/controllers/clientcontrollers/profile_ingest_controller_test.go
@@ -1,0 +1,167 @@
+//go:build !pgch
+
+package clientcontrollers
+
+import (
+	"bytes"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/pprof/profile"
+	"github.com/google/uuid"
+	"github.com/tracewayapp/lit/v2"
+	"github.com/tracewayapp/traceway/backend/app/db"
+	"github.com/tracewayapp/traceway/backend/app/middleware"
+	"github.com/tracewayapp/traceway/backend/app/models"
+	_ "modernc.org/sqlite"
+)
+
+func setupProfilingDB(t *testing.T) {
+	t.Helper()
+	telemetryDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	telemetryDB.SetMaxOpenConns(1)
+	ddl := []string{
+		`CREATE TABLE profiling_stacks (
+			project_id TEXT NOT NULL, service_name TEXT NOT NULL DEFAULT '',
+			stack_hash INTEGER NOT NULL, stack TEXT NOT NULL DEFAULT '[]',
+			last_seen DATETIME NOT NULL, UNIQUE(project_id, service_name, stack_hash))`,
+		`CREATE TABLE profiling_samples (
+			project_id TEXT NOT NULL, profile_id TEXT NOT NULL, service_name TEXT NOT NULL DEFAULT '',
+			type TEXT NOT NULL DEFAULT '', start_time DATETIME NOT NULL, end_time DATETIME NOT NULL,
+			stack_hash INTEGER NOT NULL, value INTEGER NOT NULL DEFAULT 0, labels TEXT NOT NULL DEFAULT '{}',
+			server_name TEXT NOT NULL DEFAULT '', app_version TEXT NOT NULL DEFAULT '',
+			trace_id TEXT NOT NULL DEFAULT '', span_id TEXT NOT NULL DEFAULT '')`,
+		`CREATE TABLE profiles (
+			id TEXT NOT NULL, project_id TEXT NOT NULL, recorded_at DATETIME NOT NULL,
+			duration INTEGER NOT NULL DEFAULT 0, service_name TEXT NOT NULL DEFAULT '',
+			profile_type TEXT NOT NULL DEFAULT '', sample_count INTEGER NOT NULL DEFAULT 0,
+			total_value INTEGER NOT NULL DEFAULT 0, server_name TEXT NOT NULL DEFAULT '',
+			app_version TEXT NOT NULL DEFAULT '', attributes TEXT NOT NULL DEFAULT '{}',
+			storage_key TEXT NOT NULL DEFAULT '', trace_id TEXT NOT NULL DEFAULT '',
+			span_id TEXT NOT NULL DEFAULT '', distributed_trace_id TEXT DEFAULT NULL)`,
+	}
+	for _, stmt := range ddl {
+		if _, err := telemetryDB.Exec(stmt); err != nil {
+			t.Fatalf("ddl: %v", err)
+		}
+	}
+	prevDB, prevDriver := db.TelemetryDB, db.Driver
+	db.TelemetryDB = telemetryDB
+	db.Driver = lit.SQLite
+	t.Cleanup(func() {
+		telemetryDB.Close()
+		db.TelemetryDB = prevDB
+		db.Driver = prevDriver
+	})
+}
+
+func cpuPprof(t *testing.T) []byte {
+	t.Helper()
+	main := &profile.Function{ID: 1, Name: "main.main", Filename: "main.go"}
+	work := &profile.Function{ID: 2, Name: "main.work", Filename: "work.go"}
+	idle := &profile.Function{ID: 3, Name: "main.idle", Filename: "idle.go"}
+	lMain := &profile.Location{ID: 1, Line: []profile.Line{{Function: main, Line: 10}}}
+	lWork := &profile.Location{ID: 2, Line: []profile.Line{{Function: work, Line: 20}}}
+	lIdle := &profile.Location{ID: 3, Line: []profile.Line{{Function: idle, Line: 30}}}
+	p := &profile.Profile{
+		SampleType: []*profile.ValueType{
+			{Type: "samples", Unit: "count"},
+			{Type: "cpu", Unit: "nanoseconds"},
+		},
+		PeriodType:    &profile.ValueType{Type: "cpu", Unit: "nanoseconds"},
+		Period:        10_000_000,
+		TimeNanos:     1_700_000_000_000_000_000,
+		DurationNanos: 30_000_000_000,
+		Sample: []*profile.Sample{
+			{Location: []*profile.Location{lWork, lMain}, Value: []int64{1, 300}},
+			{Location: []*profile.Location{lIdle, lMain}, Value: []int64{1, 100}},
+		},
+		Function: []*profile.Function{main, work, idle},
+		Location: []*profile.Location{lMain, lWork, lIdle},
+	}
+	var buf bytes.Buffer
+	if err := p.Write(&buf); err != nil {
+		t.Fatalf("write pprof: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func newIngestContext(t *testing.T, projectId uuid.UUID, projectName, target string, body []byte) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, target, bytes.NewReader(body))
+	c.Set(middleware.ProjectIdContextKey, projectId)
+	c.Set(middleware.ProjectContextKey, &models.Project{Id: projectId, Name: projectName})
+	return c, w
+}
+
+func TestProfileIngest_StoresExplodedRows(t *testing.T) {
+	setupProfilingDB(t)
+	projectId := uuid.New()
+	c, w := newIngestContext(t, projectId, "checkout-svc", "/profiles/ingest?serverName=pod-a&appVersion=9.9.9", cpuPprof(t))
+
+	ProfileIngestController.Ingest(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var stacks, samples, profiles int
+	db.TelemetryDB.QueryRow("SELECT COUNT(*) FROM profiling_stacks").Scan(&stacks)
+	db.TelemetryDB.QueryRow("SELECT COUNT(*) FROM profiling_samples").Scan(&samples)
+	db.TelemetryDB.QueryRow("SELECT COUNT(*) FROM profiles").Scan(&profiles)
+	if stacks != 2 {
+		t.Errorf("profiling_stacks = %d, want 2", stacks)
+	}
+	if samples != 2 {
+		t.Errorf("profiling_samples = %d, want 2", samples)
+	}
+	if profiles != 1 {
+		t.Errorf("profiles = %d, want 1 (cpu only)", profiles)
+	}
+
+	var service, server, version string
+	db.TelemetryDB.QueryRow("SELECT service_name, server_name, app_version FROM profiles LIMIT 1").Scan(&service, &server, &version)
+	if service != "checkout-svc" {
+		t.Errorf("service_name = %q, want project-name default %q", service, "checkout-svc")
+	}
+	if server != "pod-a" || version != "9.9.9" {
+		t.Errorf("provenance from query params wrong: server=%q version=%q", server, version)
+	}
+}
+
+func TestProfileIngest_ExplicitServiceQueryOverridesDefault(t *testing.T) {
+	setupProfilingDB(t)
+	projectId := uuid.New()
+	c, w := newIngestContext(t, projectId, "checkout-svc", "/profiles/ingest?service=billing", cpuPprof(t))
+
+	ProfileIngestController.Ingest(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var service string
+	db.TelemetryDB.QueryRow("SELECT service_name FROM profiles LIMIT 1").Scan(&service)
+	if service != "billing" {
+		t.Errorf("service_name = %q, want explicit query value %q", service, "billing")
+	}
+}
+
+func TestProfileIngest_RejectsGarbage(t *testing.T) {
+	setupProfilingDB(t)
+	projectId := uuid.New()
+	c, w := newIngestContext(t, projectId, "checkout-svc", "/profiles/ingest", []byte("not a pprof payload"))
+
+	ProfileIngestController.Ingest(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for garbage body", w.Code)
+	}
+}

--- a/backend/app/controllers/profile.controller.go
+++ b/backend/app/controllers/profile.controller.go
@@ -85,6 +85,10 @@ func (p profileController) GetSeries(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	if request.ServiceName == "" || request.Type == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "serviceName and type are required"})
+		return
+	}
 
 	points, err := repositories.ProfileRepository.GetSeries(c, projectId, request.ServiceName, request.Type, request.FromDate, request.ToDate, request.IntervalMinutes)
 	if err != nil {
@@ -109,6 +113,10 @@ func (p profileController) GetFlameGraph(c *gin.Context) {
 	var request ProfileFlameGraphRequest
 	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if request.ServiceName == "" || request.Type == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "serviceName and type are required"})
 		return
 	}
 

--- a/backend/app/controllers/profile.controller.go
+++ b/backend/app/controllers/profile.controller.go
@@ -1,0 +1,124 @@
+package controllers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tracewayapp/traceway/backend/app/middleware"
+	"github.com/tracewayapp/traceway/backend/app/models"
+	"github.com/tracewayapp/traceway/backend/app/repositories"
+	"github.com/tracewayapp/traceway/backend/app/services"
+	traceway "go.tracewayapp.com"
+)
+
+type profileController struct{}
+
+type ProfileGroupedRequest struct {
+	FromDate      time.Time        `json:"fromDate"`
+	ToDate        time.Time        `json:"toDate"`
+	OrderBy       string           `json:"orderBy"`
+	SortDirection string           `json:"sortDirection"`
+	Pagination    PaginationParams `json:"pagination"`
+}
+
+type ProfileSeriesRequest struct {
+	FromDate        time.Time `json:"fromDate"`
+	ToDate          time.Time `json:"toDate"`
+	ServiceName     string    `json:"serviceName"`
+	Type            string    `json:"type"`
+	IntervalMinutes int       `json:"intervalMinutes"`
+}
+
+type ProfileFlameGraphRequest struct {
+	FromDate    time.Time         `json:"fromDate"`
+	ToDate      time.Time         `json:"toDate"`
+	ServiceName string            `json:"serviceName"`
+	Type        string            `json:"type"`
+	Labels      map[string]string `json:"labels"`
+}
+
+type ProfileSeriesPoint struct {
+	Timestamp time.Time `json:"timestamp"`
+	Value     float64   `json:"value"`
+}
+
+func (p profileController) FindGroupedByService(c *gin.Context) {
+	projectId, err := middleware.GetProjectId(c)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("RequireProjectAccess middleware must be applied: %w", err))
+		return
+	}
+
+	var request ProfileGroupedRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	groups, total, err := repositories.ProfileRepository.FindGroupedByService(c, projectId, request.FromDate, request.ToDate, request.Pagination.Page, request.Pagination.PageSize, request.OrderBy, request.SortDirection)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("error loading grouped profiles: %w", err))
+		return
+	}
+
+	c.JSON(http.StatusOK, PaginatedResponse[models.ProfileGroup]{
+		Data: groups,
+		Pagination: Pagination{
+			Page:       request.Pagination.Page,
+			PageSize:   request.Pagination.PageSize,
+			Total:      total,
+			TotalPages: (total + int64(request.Pagination.PageSize) - 1) / int64(request.Pagination.PageSize),
+		},
+	})
+}
+
+func (p profileController) GetSeries(c *gin.Context) {
+	projectId, err := middleware.GetProjectId(c)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("RequireProjectAccess middleware must be applied: %w", err))
+		return
+	}
+
+	var request ProfileSeriesRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	points, err := repositories.ProfileRepository.GetSeries(c, projectId, request.ServiceName, request.Type, request.FromDate, request.ToDate, request.IntervalMinutes)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("error loading profile series: %w", err))
+		return
+	}
+
+	out := make([]ProfileSeriesPoint, 0, len(points))
+	for _, pt := range points {
+		out = append(out, ProfileSeriesPoint{Timestamp: pt.Timestamp, Value: pt.Value})
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (p profileController) GetFlameGraph(c *gin.Context) {
+	projectId, err := middleware.GetProjectId(c)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("RequireProjectAccess middleware must be applied: %w", err))
+		return
+	}
+
+	var request ProfileFlameGraphRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	rows, err := repositories.ProfileRepository.GetFlameGraph(c, projectId, request.ServiceName, request.Type, request.FromDate, request.ToDate, request.Labels)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("error loading flame graph: %w", err))
+		return
+	}
+
+	c.JSON(http.StatusOK, services.FoldFlameGraph(rows))
+}
+
+var ProfileController = profileController{}

--- a/backend/app/controllers/routes.go
+++ b/backend/app/controllers/routes.go
@@ -32,6 +32,9 @@ func RegisterControllers(router *gin.RouterGroup) {
 	router.OPTIONS("/report", middleware.CORSReport)
 	router.POST("/report", middleware.CORSReport, middleware.UseClientAuth, middleware.UseGzip, clientcontrollers.ClientController.Report)
 
+	router.OPTIONS("/profiles/ingest", middleware.CORSReport)
+	router.POST("/profiles/ingest", middleware.CORSReport, middleware.UseClientAuth, middleware.UseGzip, clientcontrollers.ProfileIngestController.Ingest)
+
 	otelGroup := router.Group("/otel")
 	otelGroup.OPTIONS("/v1/traces", middleware.CORSReport)
 	otelGroup.OPTIONS("/v1/metrics", middleware.CORSReport)
@@ -90,6 +93,10 @@ func RegisterControllers(router *gin.RouterGroup) {
 	router.POST("/sessions", middleware.UseAppAuth, middleware.RequireProjectAccess, SessionController.FindAllSessions)
 	router.POST("/sessions/:sessionId", middleware.UseAppAuth, middleware.RequireProjectAccess, SessionDetailController.GetSessionDetail)
 	router.GET("/sessions/:sessionId/recording", middleware.UseAppAuth, middleware.RequireProjectAccess, SessionDetailController.GetSessionRecording)
+
+	router.POST("/profiles/grouped", middleware.UseAppAuth, middleware.RequireProjectAccess, ProfileController.FindGroupedByService)
+	router.POST("/profiles/series", middleware.UseAppAuth, middleware.RequireProjectAccess, ProfileController.GetSeries)
+	router.POST("/profiles/flamegraph", middleware.UseAppAuth, middleware.RequireProjectAccess, ProfileController.GetFlameGraph)
 
 	router.POST("/ai-traces/grouped", middleware.UseAppAuth, middleware.RequireProjectAccess, AiTraceController.FindGroupedByTraceName)
 	router.POST("/ai-traces/trace", middleware.UseAppAuth, middleware.RequireProjectAccess, AiTraceController.FindByTraceName)

--- a/backend/app/models/profile.model.go
+++ b/backend/app/models/profile.model.go
@@ -30,6 +30,20 @@ type ProfileSample struct {
 	SpanId      string            `json:"spanId" ch:"span_id"`
 }
 
+type ProfileGroup struct {
+	ServiceName  string    `json:"serviceName" ch:"service_name"`
+	Type         string    `json:"type" ch:"profile_type"`
+	ProfileCount int64     `json:"profileCount" ch:"profile_count"`
+	SampleCount  int64     `json:"sampleCount" ch:"sample_count"`
+	TotalValue   int64     `json:"totalValue" ch:"total_value"`
+	LastSeen     time.Time `json:"lastSeen" ch:"last_seen"`
+}
+
+type ProfileStackValue struct {
+	Stack []string `json:"stack"`
+	Value int64    `json:"value"`
+}
+
 type Profile struct {
 	Id                 uuid.UUID         `json:"id" ch:"id"`
 	ProjectId          uuid.UUID         `json:"projectId" ch:"project_id"`

--- a/backend/app/profiling/build_rows.go
+++ b/backend/app/profiling/build_rows.go
@@ -1,0 +1,74 @@
+package profiling
+
+import (
+	"github.com/google/uuid"
+	"github.com/tracewayapp/traceway/backend/app/models"
+)
+
+func BuildRows(d Decoded, projectId uuid.UUID) ([]models.ProfileStack, []models.ProfileSample, []models.Profile) {
+	stacks := make([]models.ProfileStack, 0, len(d.Stacks))
+	for _, s := range d.Stacks {
+		stacks = append(stacks, models.ProfileStack{
+			ProjectId:   projectId,
+			ServiceName: d.Meta.ServiceName,
+			StackHash:   s.Hash,
+			Stack:       s.Frames,
+			LastSeen:    d.Meta.End,
+		})
+	}
+
+	traceId, spanId := "", ""
+	if d.Meta.TraceId != nil {
+		traceId = *d.Meta.TraceId
+	}
+	if d.Meta.SpanId != nil {
+		spanId = *d.Meta.SpanId
+	}
+
+	profileByType := map[string]*models.Profile{}
+	var typeOrder []string
+	samples := make([]models.ProfileSample, 0, len(d.Samples))
+	for _, s := range d.Samples {
+		p := profileByType[s.Type]
+		if p == nil {
+			p = &models.Profile{
+				Id:          uuid.New(),
+				ProjectId:   projectId,
+				RecordedAt:  d.Meta.Start,
+				Duration:    d.Meta.End.Sub(d.Meta.Start),
+				ServiceName: d.Meta.ServiceName,
+				ProfileType: s.Type,
+				ServerName:  d.Meta.ServerName,
+				AppVersion:  d.Meta.AppVersion,
+				Attributes:  d.Meta.Attributes,
+				TraceId:     traceId,
+				SpanId:      spanId,
+			}
+			profileByType[s.Type] = p
+			typeOrder = append(typeOrder, s.Type)
+		}
+		p.SampleCount++
+		p.TotalValue += s.Value
+		samples = append(samples, models.ProfileSample{
+			ProjectId:   projectId,
+			ProfileId:   p.Id,
+			ServiceName: d.Meta.ServiceName,
+			Type:        s.Type,
+			Start:       d.Meta.Start,
+			End:         d.Meta.End,
+			StackHash:   s.StackHash,
+			Value:       s.Value,
+			ServerName:  d.Meta.ServerName,
+			AppVersion:  d.Meta.AppVersion,
+			TraceId:     traceId,
+			SpanId:      spanId,
+		})
+	}
+
+	profiles := make([]models.Profile, 0, len(typeOrder))
+	for _, t := range typeOrder {
+		profiles = append(profiles, *profileByType[t])
+	}
+
+	return stacks, samples, profiles
+}

--- a/backend/app/profiling/build_rows_test.go
+++ b/backend/app/profiling/build_rows_test.go
@@ -1,0 +1,130 @@
+package profiling
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tracewayapp/traceway/backend/app/models"
+)
+
+func TestBuildRows_PerTypeProfileRows(t *testing.T) {
+	projectId := uuid.MustParse("00000000-0000-0000-0000-000000000007")
+	start := time.Unix(1_700_000_000, 0).UTC()
+	d := Decoded{
+		Meta: Meta{
+			ServiceName: "checkout",
+			Start:       start,
+			End:         start.Add(30 * time.Second),
+			ServerName:  "pod-a",
+			AppVersion:  "1.2.3",
+		},
+		Stacks: []Stack{
+			{Hash: 0xAA, Frames: []string{"main.main", "main.work"}},
+		},
+		Samples: []Sample{
+			{Type: TypeHeapAllocSpace, StackHash: 0xAA, Value: 4096},
+			{Type: TypeHeapInuseSpace, StackHash: 0xAA, Value: 2048},
+		},
+	}
+
+	stacks, samples, profiles := BuildRows(d, projectId)
+
+	if len(stacks) != 1 {
+		t.Fatalf("expected 1 stack, got %d", len(stacks))
+	}
+	if stacks[0].ProjectId != projectId || stacks[0].ServiceName != "checkout" || stacks[0].StackHash != 0xAA {
+		t.Errorf("stack identity wrong: %+v", stacks[0])
+	}
+	if !stacks[0].LastSeen.Equal(d.Meta.End) {
+		t.Errorf("stack LastSeen = %v, want profile End %v", stacks[0].LastSeen, d.Meta.End)
+	}
+
+	if len(profiles) != 2 {
+		t.Fatalf("expected one profile row per type (alloc + inuse), got %d", len(profiles))
+	}
+	byType := map[string]models.Profile{}
+	for _, p := range profiles {
+		byType[p.ProfileType] = p
+		if p.Id == uuid.Nil {
+			t.Errorf("profile %q has nil id", p.ProfileType)
+		}
+		if p.ProjectId != projectId || p.ServiceName != "checkout" {
+			t.Errorf("profile identity wrong: %+v", p)
+		}
+		if p.ServerName != "pod-a" || p.AppVersion != "1.2.3" {
+			t.Errorf("profile provenance not carried: %+v", p)
+		}
+		if !p.RecordedAt.Equal(start) {
+			t.Errorf("profile RecordedAt = %v, want %v", p.RecordedAt, start)
+		}
+		if p.Duration != 30*time.Second {
+			t.Errorf("profile Duration = %v, want 30s", p.Duration)
+		}
+		if p.SampleCount != 1 {
+			t.Errorf("profile %q SampleCount = %d, want 1", p.ProfileType, p.SampleCount)
+		}
+	}
+	if alloc, ok := byType[TypeHeapAllocSpace]; !ok || alloc.TotalValue != 4096 {
+		t.Errorf("alloc profile TotalValue = %d, want 4096", alloc.TotalValue)
+	}
+	if inuse, ok := byType[TypeHeapInuseSpace]; !ok || inuse.TotalValue != 2048 {
+		t.Errorf("inuse profile TotalValue = %d, want 2048", inuse.TotalValue)
+	}
+	if byType[TypeHeapAllocSpace].Id == byType[TypeHeapInuseSpace].Id {
+		t.Error("per-type profiles must have distinct ids")
+	}
+
+	if len(samples) != 2 {
+		t.Fatalf("expected 2 samples, got %d", len(samples))
+	}
+	for _, s := range samples {
+		want := byType[s.Type]
+		if s.ProfileId != want.Id {
+			t.Errorf("sample type %q ProfileId = %v, want matching profile id %v", s.Type, s.ProfileId, want.Id)
+		}
+		if s.ProjectId != projectId || s.ServiceName != "checkout" || s.StackHash != 0xAA {
+			t.Errorf("sample identity wrong: %+v", s)
+		}
+		if !s.Start.Equal(start) || !s.End.Equal(start.Add(30*time.Second)) {
+			t.Errorf("sample window wrong: %+v", s)
+		}
+		if s.ServerName != "pod-a" || s.AppVersion != "1.2.3" {
+			t.Errorf("sample provenance not carried: %+v", s)
+		}
+	}
+}
+
+func TestBuildRows_CPUSingleType(t *testing.T) {
+	projectId := uuid.New()
+	start := time.Unix(1_700_000_500, 0).UTC()
+	d := Decoded{
+		Meta:   Meta{ServiceName: "api", Start: start, End: start.Add(10 * time.Second)},
+		Stacks: []Stack{{Hash: 1, Frames: []string{"main.main"}}, {Hash: 2, Frames: []string{"main.main", "main.idle"}}},
+		Samples: []Sample{
+			{Type: TypeCPUNanos, StackHash: 1, Value: 300},
+			{Type: TypeCPUNanos, StackHash: 2, Value: 100},
+		},
+	}
+
+	_, samples, profiles := BuildRows(d, projectId)
+
+	if len(profiles) != 1 {
+		t.Fatalf("expected 1 cpu profile, got %d", len(profiles))
+	}
+	p := profiles[0]
+	if p.ProfileType != TypeCPUNanos {
+		t.Errorf("ProfileType = %q, want %q", p.ProfileType, TypeCPUNanos)
+	}
+	if p.TotalValue != 400 {
+		t.Errorf("TotalValue = %d, want 400 (300+100)", p.TotalValue)
+	}
+	if p.SampleCount != 2 {
+		t.Errorf("SampleCount = %d, want 2", p.SampleCount)
+	}
+	for _, s := range samples {
+		if s.ProfileId != p.Id {
+			t.Errorf("sample ProfileId = %v, want %v", s.ProfileId, p.Id)
+		}
+	}
+}

--- a/backend/app/profiling/model.go
+++ b/backend/app/profiling/model.go
@@ -19,6 +19,10 @@ var keptSampleTypes = map[string]string{
 	"alloc_space": TypeHeapAllocSpace,
 }
 
+func IsGauge(profileType string) bool {
+	return profileType == TypeHeapInuseSpace
+}
+
 type Stack struct {
 	Hash   uint64
 	Frames []string

--- a/backend/app/repositories/profile.repository.go
+++ b/backend/app/repositories/profile.repository.go
@@ -5,12 +5,19 @@ package repositories
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/tracewayapp/traceway/backend/app/chdb"
 	"github.com/tracewayapp/traceway/backend/app/models"
+	"github.com/tracewayapp/traceway/backend/app/profiling"
 )
 
 type profileRepository struct{}
+
+const profileStackDedup = `(SELECT project_id, service_name, stack_hash, any(stack) AS stack FROM profiling_stacks GROUP BY project_id, service_name, stack_hash)`
 
 func (r *profileRepository) InsertStacksAsync(ctx context.Context, stacks []models.ProfileStack) error {
 	if len(stacks) == 0 {
@@ -78,6 +85,163 @@ func (r *profileRepository) InsertProfilesAsync(ctx context.Context, profiles []
 		}
 	}
 	return batch.Send()
+}
+
+func (r *profileRepository) FindGroupedByService(ctx context.Context, projectId uuid.UUID, from, to time.Time, page, pageSize int, orderBy, sortDirection string) ([]models.ProfileGroup, int64, error) {
+	var count uint64
+	err := chdb.Conn.QueryRow(ctx,
+		`SELECT count() FROM (SELECT service_name, profile_type FROM profiles
+			WHERE project_id = ? AND recorded_at >= ? AND recorded_at <= ?
+			GROUP BY service_name, profile_type)`, projectId, from, to).Scan(&count)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	orderByMap := map[string]string{
+		"total_value":   "total_value",
+		"sample_count":  "sample_count",
+		"profile_count": "profile_count",
+		"last_seen":     "last_seen",
+	}
+	orderExpr, ok := orderByMap[orderBy]
+	if !ok {
+		orderExpr = "total_value"
+	}
+	sortDir := "DESC"
+	if sortDirection == "asc" {
+		sortDir = "ASC"
+	}
+	offset := (page - 1) * pageSize
+
+	query := fmt.Sprintf(`SELECT service_name, profile_type,
+			count() AS profile_count,
+			sum(sample_count) AS sample_count,
+			sum(total_value) AS total_value,
+			max(recorded_at) AS last_seen
+		FROM profiles
+		WHERE project_id = ? AND recorded_at >= ? AND recorded_at <= ?
+		GROUP BY service_name, profile_type
+		ORDER BY %s %s
+		LIMIT ? OFFSET ?`, orderExpr, sortDir)
+
+	rows, err := chdb.Conn.Query(ctx, query, projectId, from, to, pageSize, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var groups []models.ProfileGroup
+	for rows.Next() {
+		var g models.ProfileGroup
+		var profileCount, sampleCount uint64
+		if err := rows.Scan(&g.ServiceName, &g.Type, &profileCount, &sampleCount, &g.TotalValue, &g.LastSeen); err != nil {
+			return nil, 0, err
+		}
+		g.ProfileCount = int64(profileCount)
+		g.SampleCount = int64(sampleCount)
+		groups = append(groups, g)
+	}
+	return groups, int64(count), nil
+}
+
+func (r *profileRepository) GetSeries(ctx context.Context, projectId uuid.UUID, service, profileType string, from, to time.Time, intervalMinutes int) ([]models.TimeSeriesPoint, error) {
+	if intervalMinutes < 1 {
+		intervalMinutes = 1
+	}
+	agg := "sum"
+	if profiling.IsGauge(profileType) {
+		agg = "avg"
+	}
+
+	query := fmt.Sprintf(`SELECT toStartOfInterval(start_time, INTERVAL ? MINUTE) AS bucket,
+			toFloat64(%s(value)) AS agg_value
+		FROM profiling_samples
+		WHERE project_id = ? AND type = ? AND service_name = ? AND start_time >= ? AND start_time <= ?
+		GROUP BY bucket ORDER BY bucket ASC`, agg)
+
+	rows, err := chdb.Conn.Query(ctx, query, intervalMinutes, projectId, profileType, service, from, to)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var points []models.TimeSeriesPoint
+	for rows.Next() {
+		var p models.TimeSeriesPoint
+		if err := rows.Scan(&p.Timestamp, &p.Value); err != nil {
+			return nil, err
+		}
+		points = append(points, p)
+	}
+	return points, nil
+}
+
+func (r *profileRepository) GetFlameGraph(ctx context.Context, projectId uuid.UUID, service, profileType string, from, to time.Time, labelFilters map[string]string) ([]models.ProfileStackValue, error) {
+	bareFilter, bareArgs := chLabelFilter("", labelFilters)
+	aliasFilter, aliasArgs := chLabelFilter("s.", labelFilters)
+
+	var query string
+	var args []interface{}
+	if profiling.IsGauge(profileType) {
+		query = `WITH latest AS (
+			SELECT server_name, max(start_time) AS mx FROM profiling_samples
+			WHERE project_id = ? AND type = ? AND service_name = ? AND start_time >= ? AND start_time <= ?` + bareFilter + `
+			GROUP BY server_name)
+		SELECT st.stack, sum(s.value) AS v
+		FROM profiling_samples s
+		INNER JOIN latest l ON l.server_name = s.server_name AND l.mx = s.start_time
+		INNER JOIN ` + profileStackDedup + ` st ON st.project_id = s.project_id AND st.service_name = s.service_name AND st.stack_hash = s.stack_hash
+		WHERE s.project_id = ? AND s.type = ? AND s.service_name = ? AND s.start_time >= ? AND s.start_time <= ?` + aliasFilter + `
+		GROUP BY s.stack_hash, st.stack`
+		args = append(args, projectId, profileType, service, from, to)
+		args = append(args, bareArgs...)
+		args = append(args, projectId, profileType, service, from, to)
+		args = append(args, aliasArgs...)
+	} else {
+		query = `SELECT st.stack, sum(s.value) AS v
+		FROM profiling_samples s
+		INNER JOIN ` + profileStackDedup + ` st ON st.project_id = s.project_id AND st.service_name = s.service_name AND st.stack_hash = s.stack_hash
+		WHERE s.project_id = ? AND s.type = ? AND s.service_name = ? AND s.start_time >= ? AND s.start_time <= ?` + aliasFilter + `
+		GROUP BY s.stack_hash, st.stack`
+		args = append(args, projectId, profileType, service, from, to)
+		args = append(args, aliasArgs...)
+	}
+
+	rows, err := chdb.Conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []models.ProfileStackValue
+	for rows.Next() {
+		var frames []string
+		var value int64
+		if err := rows.Scan(&frames, &value); err != nil {
+			return nil, err
+		}
+		out = append(out, models.ProfileStackValue{Stack: frames, Value: value})
+	}
+	return out, nil
+}
+
+func chLabelFilter(qualifier string, filters map[string]string) (string, []interface{}) {
+	if len(filters) == 0 {
+		return "", nil
+	}
+	keys := make([]string, 0, len(filters))
+	for k := range filters {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	clause := ""
+	var args []interface{}
+	for _, k := range keys {
+		clause += fmt.Sprintf(" AND %slabels[?] = ?", qualifier)
+		args = append(args, k, filters[k])
+	}
+	return clause, args
 }
 
 var ProfileRepository = profileRepository{}

--- a/backend/app/repositories/profile.repository.go
+++ b/backend/app/repositories/profile.repository.go
@@ -17,7 +17,7 @@ import (
 
 type profileRepository struct{}
 
-const profileStackDedup = `(SELECT project_id, service_name, stack_hash, any(stack) AS stack FROM profiling_stacks GROUP BY project_id, service_name, stack_hash)`
+const profileStackDedup = `(SELECT project_id, service_name, stack_hash, any(stack) AS stack FROM profiling_stacks WHERE project_id = ? AND service_name = ? GROUP BY project_id, service_name, stack_hash)`
 
 func (r *profileRepository) InsertStacksAsync(ctx context.Context, stacks []models.ProfileStack) error {
 	if len(stacks) == 0 {
@@ -184,17 +184,18 @@ func (r *profileRepository) GetFlameGraph(ctx context.Context, projectId uuid.UU
 	var args []interface{}
 	if profiling.IsGauge(profileType) {
 		query = `WITH latest AS (
-			SELECT server_name, max(start_time) AS mx FROM profiling_samples
+			SELECT argMax(profile_id, start_time) AS pid FROM profiling_samples
 			WHERE project_id = ? AND type = ? AND service_name = ? AND start_time >= ? AND start_time <= ?` + bareFilter + `
 			GROUP BY server_name)
 		SELECT st.stack, sum(s.value) AS v
 		FROM profiling_samples s
-		INNER JOIN latest l ON l.server_name = s.server_name AND l.mx = s.start_time
+		INNER JOIN latest l ON l.pid = s.profile_id
 		INNER JOIN ` + profileStackDedup + ` st ON st.project_id = s.project_id AND st.service_name = s.service_name AND st.stack_hash = s.stack_hash
 		WHERE s.project_id = ? AND s.type = ? AND s.service_name = ? AND s.start_time >= ? AND s.start_time <= ?` + aliasFilter + `
 		GROUP BY s.stack_hash, st.stack`
 		args = append(args, projectId, profileType, service, from, to)
 		args = append(args, bareArgs...)
+		args = append(args, projectId, service)
 		args = append(args, projectId, profileType, service, from, to)
 		args = append(args, aliasArgs...)
 	} else {
@@ -203,6 +204,7 @@ func (r *profileRepository) GetFlameGraph(ctx context.Context, projectId uuid.UU
 		INNER JOIN ` + profileStackDedup + ` st ON st.project_id = s.project_id AND st.service_name = s.service_name AND st.stack_hash = s.stack_hash
 		WHERE s.project_id = ? AND s.type = ? AND s.service_name = ? AND s.start_time >= ? AND s.start_time <= ?` + aliasFilter + `
 		GROUP BY s.stack_hash, st.stack`
+		args = append(args, projectId, service)
 		args = append(args, projectId, profileType, service, from, to)
 		args = append(args, aliasArgs...)
 	}

--- a/backend/app/repositories/profile.repository_sqlite.go
+++ b/backend/app/repositories/profile.repository_sqlite.go
@@ -241,14 +241,14 @@ func (r *profileRepository) GetFlameGraph(ctx context.Context, projectId uuid.UU
 	var query string
 	if profiling.IsGauge(profileType) {
 		query = `WITH latest AS (
-			SELECT server_name, MAX(start_time) AS mx
+			SELECT profile_id AS pid, MAX(start_time) AS mx
 			FROM profiling_samples
 			WHERE project_id = :project_id AND type = :type AND service_name = :service
 				AND start_time >= :from AND start_time <= :to` + bareFilter + `
 			GROUP BY server_name)
 		SELECT st.stack AS stack_json, CAST(SUM(s.value) AS INTEGER) AS v
 		FROM profiling_samples s
-		JOIN latest l ON l.server_name = s.server_name AND l.mx = s.start_time
+		JOIN latest l ON l.pid = s.profile_id
 		JOIN profiling_stacks st ON st.project_id = s.project_id AND st.service_name = s.service_name AND st.stack_hash = s.stack_hash
 		WHERE s.project_id = :project_id AND s.type = :type AND s.service_name = :service
 			AND s.start_time >= :from AND s.start_time <= :to` + aliasFilter + `

--- a/backend/app/repositories/profile.repository_sqlite.go
+++ b/backend/app/repositories/profile.repository_sqlite.go
@@ -5,11 +5,31 @@ package repositories
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/tracewayapp/lit/v2"
 	"github.com/tracewayapp/traceway/backend/app/db"
 	"github.com/tracewayapp/traceway/backend/app/models"
+	"github.com/tracewayapp/traceway/backend/app/profiling"
 )
+
+type profileGroupRow struct {
+	ServiceName  string     `lit:"service_name"`
+	ProfileType  string     `lit:"profile_type"`
+	ProfileCount int64      `lit:"profile_count"`
+	SampleCount  int64      `lit:"sample_count"`
+	TotalValue   int64      `lit:"total_value"`
+	LastSeen     SQLiteTime `lit:"last_seen"`
+}
+
+func init() {
+	models.ExtensionModelRegistrations = append(models.ExtensionModelRegistrations, func(driver lit.Driver) {
+		lit.RegisterModel[profileGroupRow](driver)
+	})
+}
 
 type profileRepository struct{}
 
@@ -125,6 +145,168 @@ func (r *profileRepository) InsertProfilesAsync(ctx context.Context, profiles []
 		}
 	}
 	return tx.Commit()
+}
+
+func (r *profileRepository) FindGroupedByService(ctx context.Context, projectId uuid.UUID, from, to time.Time, page, pageSize int, orderBy, sortDirection string) ([]models.ProfileGroup, int64, error) {
+	params := lit.P{"project_id": projectId, "from": NewSQLiteTime(from), "to": NewSQLiteTime(to)}
+
+	countResult, err := lit.SelectSingleNamed[models.CountResult](db.TelemetryDB,
+		`SELECT COUNT(*) AS count FROM (
+			SELECT 1 FROM profiles
+			WHERE project_id = :project_id AND recorded_at >= :from AND recorded_at <= :to
+			GROUP BY service_name, profile_type)`, params)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := int64(0)
+	if countResult != nil {
+		total = int64(countResult.Count)
+	}
+
+	orderByMap := map[string]string{
+		"total_value":   "total_value",
+		"sample_count":  "sample_count",
+		"profile_count": "profile_count",
+		"last_seen":     "last_seen",
+	}
+	orderExpr, ok := orderByMap[orderBy]
+	if !ok {
+		orderExpr = "total_value"
+	}
+	sortDir := "DESC"
+	if sortDirection == "asc" {
+		sortDir = "ASC"
+	}
+
+	offset := (page - 1) * pageSize
+	rows, err := lit.SelectNamed[profileGroupRow](db.TelemetryDB,
+		fmt.Sprintf(`SELECT service_name, profile_type,
+			COUNT(*) AS profile_count,
+			SUM(sample_count) AS sample_count,
+			SUM(total_value) AS total_value,
+			MAX(recorded_at) AS last_seen
+		FROM profiles
+		WHERE project_id = :project_id AND recorded_at >= :from AND recorded_at <= :to
+		GROUP BY service_name, profile_type
+		ORDER BY %s %s
+		LIMIT :limit OFFSET :offset`, orderExpr, sortDir),
+		lit.P{"project_id": projectId, "from": NewSQLiteTime(from), "to": NewSQLiteTime(to), "limit": pageSize, "offset": offset})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	groups := make([]models.ProfileGroup, 0, len(rows))
+	for _, row := range rows {
+		groups = append(groups, models.ProfileGroup{
+			ServiceName:  row.ServiceName,
+			Type:         row.ProfileType,
+			ProfileCount: row.ProfileCount,
+			SampleCount:  row.SampleCount,
+			TotalValue:   row.TotalValue,
+			LastSeen:     row.LastSeen.Time,
+		})
+	}
+	return groups, total, nil
+}
+
+func (r *profileRepository) GetSeries(ctx context.Context, projectId uuid.UUID, service, profileType string, from, to time.Time, intervalMinutes int) ([]models.TimeSeriesPoint, error) {
+	if intervalMinutes < 1 {
+		intervalMinutes = 1
+	}
+	secs := intervalMinutes * 60
+	agg := "SUM"
+	if profiling.IsGauge(profileType) {
+		agg = "AVG"
+	}
+
+	results, err := lit.SelectNamed[timeSeriesResult](db.TelemetryDB,
+		fmt.Sprintf(`SELECT datetime((strftime('%%s', start_time) / %d) * %d, 'unixepoch') AS bucket,
+			CAST(%s(value) AS REAL) AS agg_value
+		FROM profiling_samples
+		WHERE project_id = :project_id AND type = :type AND service_name = :service
+			AND start_time >= :from AND start_time <= :to
+		GROUP BY bucket ORDER BY bucket ASC`, secs, secs, agg),
+		lit.P{"project_id": projectId, "type": profileType, "service": service, "from": NewSQLiteTime(from), "to": NewSQLiteTime(to)})
+	if err != nil {
+		return nil, err
+	}
+	return timeSeriesResultsToPoints(results), nil
+}
+
+func (r *profileRepository) GetFlameGraph(ctx context.Context, projectId uuid.UUID, service, profileType string, from, to time.Time, labelFilters map[string]string) ([]models.ProfileStackValue, error) {
+	params := lit.P{"project_id": projectId, "type": profileType, "service": service, "from": NewSQLiteTime(from), "to": NewSQLiteTime(to)}
+	bareFilter := sqliteLabelFilter("", labelFilters, params)
+	aliasFilter := sqliteLabelFilter("s.", labelFilters, params)
+
+	var query string
+	if profiling.IsGauge(profileType) {
+		query = `WITH latest AS (
+			SELECT server_name, MAX(start_time) AS mx
+			FROM profiling_samples
+			WHERE project_id = :project_id AND type = :type AND service_name = :service
+				AND start_time >= :from AND start_time <= :to` + bareFilter + `
+			GROUP BY server_name)
+		SELECT st.stack AS stack_json, CAST(SUM(s.value) AS INTEGER) AS v
+		FROM profiling_samples s
+		JOIN latest l ON l.server_name = s.server_name AND l.mx = s.start_time
+		JOIN profiling_stacks st ON st.project_id = s.project_id AND st.service_name = s.service_name AND st.stack_hash = s.stack_hash
+		WHERE s.project_id = :project_id AND s.type = :type AND s.service_name = :service
+			AND s.start_time >= :from AND s.start_time <= :to` + aliasFilter + `
+		GROUP BY s.stack_hash, st.stack`
+	} else {
+		query = `SELECT st.stack AS stack_json, CAST(SUM(s.value) AS INTEGER) AS v
+		FROM profiling_samples s
+		JOIN profiling_stacks st ON st.project_id = s.project_id AND st.service_name = s.service_name AND st.stack_hash = s.stack_hash
+		WHERE s.project_id = :project_id AND s.type = :type AND s.service_name = :service
+			AND s.start_time >= :from AND s.start_time <= :to` + aliasFilter + `
+		GROUP BY s.stack_hash, st.stack`
+	}
+
+	parsed, args, err := lit.ParseNamedQuery(db.Driver, query, params)
+	if err != nil {
+		return nil, err
+	}
+	sqlRows, err := db.TelemetryDB.QueryContext(ctx, parsed, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer sqlRows.Close()
+
+	var out []models.ProfileStackValue
+	for sqlRows.Next() {
+		var stackJSON string
+		var value int64
+		if err := sqlRows.Scan(&stackJSON, &value); err != nil {
+			return nil, err
+		}
+		var frames []string
+		if err := json.Unmarshal([]byte(stackJSON), &frames); err != nil {
+			return nil, err
+		}
+		out = append(out, models.ProfileStackValue{Stack: frames, Value: value})
+	}
+	return out, sqlRows.Err()
+}
+
+func sqliteLabelFilter(qualifier string, filters map[string]string, params lit.P) string {
+	if len(filters) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(filters))
+	for k := range filters {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	clause := ""
+	for i, k := range keys {
+		pathKey := fmt.Sprintf("lblpath_%d", i)
+		valKey := fmt.Sprintf("lblval_%d", i)
+		clause += fmt.Sprintf(" AND json_extract(%slabels, :%s) = :%s", qualifier, pathKey, valKey)
+		params[pathKey] = "$." + k
+		params[valKey] = filters[k]
+	}
+	return clause
 }
 
 var ProfileRepository = profileRepository{}

--- a/backend/app/repositories/profile_query_test.go
+++ b/backend/app/repositories/profile_query_test.go
@@ -1,0 +1,216 @@
+//go:build !pgch
+
+package repositories
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tracewayapp/traceway/backend/app/models"
+	"github.com/tracewayapp/traceway/backend/app/profiling"
+)
+
+func mustInsertStacks(t *testing.T, ctx context.Context, stacks ...models.ProfileStack) {
+	t.Helper()
+	if err := ProfileRepository.InsertStacksAsync(ctx, stacks); err != nil {
+		t.Fatalf("InsertStacksAsync: %v", err)
+	}
+}
+
+func mustInsertSamples(t *testing.T, ctx context.Context, samples ...models.ProfileSample) {
+	t.Helper()
+	if err := ProfileRepository.InsertSamplesAsync(ctx, samples); err != nil {
+		t.Fatalf("InsertSamplesAsync: %v", err)
+	}
+}
+
+func mustInsertProfiles(t *testing.T, ctx context.Context, profiles ...models.Profile) {
+	t.Helper()
+	if err := ProfileRepository.InsertProfilesAsync(ctx, profiles); err != nil {
+		t.Fatalf("InsertProfilesAsync: %v", err)
+	}
+}
+
+func flameValueByStack(rows []models.ProfileStackValue) map[string]int64 {
+	out := map[string]int64{}
+	for _, r := range rows {
+		key := ""
+		for i, f := range r.Stack {
+			if i > 0 {
+				key += ";"
+			}
+			key += f
+		}
+		out[key] = r.Value
+	}
+	return out
+}
+
+func TestProfileRepository_FindGroupedByService(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	projectId := uuid.New()
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	from := base.Add(-time.Hour)
+	to := base.Add(time.Hour)
+
+	mustInsertProfiles(t, ctx,
+		models.Profile{Id: uuid.New(), ProjectId: projectId, RecordedAt: base, ServiceName: "checkout", ProfileType: profiling.TypeCPUNanos, SampleCount: 2, TotalValue: 300},
+		models.Profile{Id: uuid.New(), ProjectId: projectId, RecordedAt: base.Add(time.Minute), ServiceName: "checkout", ProfileType: profiling.TypeCPUNanos, SampleCount: 1, TotalValue: 200},
+		models.Profile{Id: uuid.New(), ProjectId: projectId, RecordedAt: base, ServiceName: "checkout", ProfileType: profiling.TypeHeapInuseSpace, SampleCount: 3, TotalValue: 9000},
+	)
+
+	groups, total, err := ProfileRepository.FindGroupedByService(ctx, projectId, from, to, 1, 50, "total_value", "desc")
+	if err != nil {
+		t.Fatalf("FindGroupedByService: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("distinct (service,type) groups = %d, want 2", total)
+	}
+
+	byType := map[string]models.ProfileGroup{}
+	for _, g := range groups {
+		if g.ServiceName != "checkout" {
+			t.Errorf("unexpected service %q", g.ServiceName)
+		}
+		byType[g.Type] = g
+	}
+	cpu := byType[profiling.TypeCPUNanos]
+	if cpu.ProfileCount != 2 || cpu.TotalValue != 500 || cpu.SampleCount != 3 {
+		t.Errorf("cpu group = %+v, want ProfileCount=2 TotalValue=500 SampleCount=3", cpu)
+	}
+	inuse := byType[profiling.TypeHeapInuseSpace]
+	if inuse.ProfileCount != 1 || inuse.TotalValue != 9000 {
+		t.Errorf("inuse group = %+v, want ProfileCount=1 TotalValue=9000", inuse)
+	}
+}
+
+func TestProfileRepository_GetFlameGraph_CounterMergesInstancesAndFiltersLabels(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	projectId := uuid.New()
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	from := base.Add(-time.Hour)
+	to := base.Add(time.Hour)
+
+	hashAB := profiling.HashFrames([]string{"a", "b"})
+	hashAC := profiling.HashFrames([]string{"a", "c"})
+	mustInsertStacks(t, ctx,
+		models.ProfileStack{ProjectId: projectId, ServiceName: "checkout", StackHash: hashAB, Stack: []string{"a", "b"}, LastSeen: base},
+		models.ProfileStack{ProjectId: projectId, ServiceName: "checkout", StackHash: hashAC, Stack: []string{"a", "c"}, LastSeen: base},
+	)
+
+	cpu := func(server string, hash uint64, value int64, env string) models.ProfileSample {
+		return models.ProfileSample{
+			ProjectId: projectId, ProfileId: uuid.New(), ServiceName: "checkout",
+			Type: profiling.TypeCPUNanos, Start: base, End: base.Add(30 * time.Second),
+			StackHash: hash, Value: value, ServerName: server, Labels: map[string]string{"env": env},
+		}
+	}
+	mustInsertSamples(t, ctx,
+		cpu("pod-a", hashAB, 200, "prod"),
+		cpu("pod-b", hashAB, 300, "prod"),
+		cpu("pod-a", hashAC, 100, "dev"),
+	)
+
+	all, err := ProfileRepository.GetFlameGraph(ctx, projectId, "checkout", profiling.TypeCPUNanos, from, to, nil)
+	if err != nil {
+		t.Fatalf("GetFlameGraph: %v", err)
+	}
+	got := flameValueByStack(all)
+	if got["a;b"] != 500 {
+		t.Errorf("a;b merged value = %d, want 500 (pod-a 200 + pod-b 300)", got["a;b"])
+	}
+	if got["a;c"] != 100 {
+		t.Errorf("a;c value = %d, want 100", got["a;c"])
+	}
+
+	prod, err := ProfileRepository.GetFlameGraph(ctx, projectId, "checkout", profiling.TypeCPUNanos, from, to, map[string]string{"env": "prod"})
+	if err != nil {
+		t.Fatalf("GetFlameGraph (filtered): %v", err)
+	}
+	gotProd := flameValueByStack(prod)
+	if gotProd["a;b"] != 500 {
+		t.Errorf("filtered a;b = %d, want 500", gotProd["a;b"])
+	}
+	if _, ok := gotProd["a;c"]; ok {
+		t.Errorf("env=prod filter must exclude the dev-only a;c stack, got %v", gotProd)
+	}
+}
+
+func TestProfileRepository_GetFlameGraph_GaugeUsesLatestPerServer(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	projectId := uuid.New()
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	from := base.Add(-time.Hour)
+	to := base.Add(time.Hour)
+
+	hashX := profiling.HashFrames([]string{"a", "b"})
+	mustInsertStacks(t, ctx,
+		models.ProfileStack{ProjectId: projectId, ServiceName: "checkout", StackHash: hashX, Stack: []string{"a", "b"}, LastSeen: base},
+	)
+
+	inuse := func(server string, start time.Time, value int64) models.ProfileSample {
+		return models.ProfileSample{
+			ProjectId: projectId, ProfileId: uuid.New(), ServiceName: "checkout",
+			Type: profiling.TypeHeapInuseSpace, Start: start, End: start,
+			StackHash: hashX, Value: value, ServerName: server,
+		}
+	}
+	t1 := base.Add(-30 * time.Minute)
+	t2 := base
+	mustInsertSamples(t, ctx,
+		inuse("pod-a", t1, 100),
+		inuse("pod-a", t2, 300),
+		inuse("pod-b", t1, 50),
+	)
+
+	rows, err := ProfileRepository.GetFlameGraph(ctx, projectId, "checkout", profiling.TypeHeapInuseSpace, from, to, nil)
+	if err != nil {
+		t.Fatalf("GetFlameGraph (gauge): %v", err)
+	}
+	got := flameValueByStack(rows)
+	if got["a;b"] != 350 {
+		t.Errorf("gauge a;b = %d, want 350 (pod-a latest 300 + pod-b 50, NOT 450)", got["a;b"])
+	}
+}
+
+func TestProfileRepository_GetSeries_CounterSumsPerBucket(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	projectId := uuid.New()
+	h12 := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	h13 := time.Date(2026, 1, 1, 13, 0, 0, 0, time.UTC)
+	from := h12.Add(-time.Minute)
+	to := h13.Add(time.Hour)
+
+	hashX := profiling.HashFrames([]string{"a"})
+	sample := func(start time.Time, value int64) models.ProfileSample {
+		return models.ProfileSample{
+			ProjectId: projectId, ProfileId: uuid.New(), ServiceName: "checkout",
+			Type: profiling.TypeCPUNanos, Start: start, End: start, StackHash: hashX, Value: value,
+		}
+	}
+	mustInsertSamples(t, ctx,
+		sample(h12.Add(5*time.Minute), 100),
+		sample(h12.Add(20*time.Minute), 200),
+		sample(h13.Add(10*time.Minute), 700),
+	)
+
+	points, err := ProfileRepository.GetSeries(ctx, projectId, "checkout", profiling.TypeCPUNanos, from, to, 60)
+	if err != nil {
+		t.Fatalf("GetSeries: %v", err)
+	}
+	if len(points) != 2 {
+		t.Fatalf("expected 2 hourly buckets, got %d (%+v)", len(points), points)
+	}
+	if points[0].Value != 300 {
+		t.Errorf("bucket 12:00 = %v, want 300 (100+200)", points[0].Value)
+	}
+	if points[1].Value != 700 {
+		t.Errorf("bucket 13:00 = %v, want 700", points[1].Value)
+	}
+}

--- a/backend/app/repositories/profile_query_test.go
+++ b/backend/app/repositories/profile_query_test.go
@@ -178,6 +178,42 @@ func TestProfileRepository_GetFlameGraph_GaugeUsesLatestPerServer(t *testing.T) 
 	}
 }
 
+func TestProfileRepository_GetFlameGraph_GaugeDedupsTiedStartTimes(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	projectId := uuid.New()
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	from := base.Add(-time.Hour)
+	to := base.Add(time.Hour)
+
+	hashX := profiling.HashFrames([]string{"a", "b"})
+	mustInsertStacks(t, ctx,
+		models.ProfileStack{ProjectId: projectId, ServiceName: "checkout", StackHash: hashX, Stack: []string{"a", "b"}, LastSeen: base},
+	)
+
+	inuse := func(server string, start time.Time, value int64) models.ProfileSample {
+		return models.ProfileSample{
+			ProjectId: projectId, ProfileId: uuid.New(), ServiceName: "checkout",
+			Type: profiling.TypeHeapInuseSpace, Start: start, End: start,
+			StackHash: hashX, Value: value, ServerName: server,
+		}
+	}
+	mustInsertSamples(t, ctx,
+		inuse("pod-a", base, 300),
+		inuse("pod-a", base, 300),
+		inuse("pod-b", base, 50),
+	)
+
+	rows, err := ProfileRepository.GetFlameGraph(ctx, projectId, "checkout", profiling.TypeHeapInuseSpace, from, to, nil)
+	if err != nil {
+		t.Fatalf("GetFlameGraph (gauge ties): %v", err)
+	}
+	got := flameValueByStack(rows)
+	if got["a;b"] != 350 {
+		t.Errorf("gauge a;b = %d, want 350 (one pod-a snapshot 300 + pod-b 50, tied start_times must not both count)", got["a;b"])
+	}
+}
+
 func TestProfileRepository_GetSeries_CounterSumsPerBucket(t *testing.T) {
 	setupTestDB(t)
 	ctx := context.Background()

--- a/backend/app/services/profile_flamegraph.go
+++ b/backend/app/services/profile_flamegraph.go
@@ -1,0 +1,57 @@
+package services
+
+import (
+	"sort"
+
+	"github.com/tracewayapp/traceway/backend/app/models"
+)
+
+type FlameNode struct {
+	Name     string       `json:"name"`
+	Value    int64        `json:"value"`
+	Self     int64        `json:"self"`
+	Children []*FlameNode `json:"children,omitempty"`
+}
+
+func FoldFlameGraph(stacks []models.ProfileStackValue) *FlameNode {
+	root := &FlameNode{Name: "root"}
+	childIndex := map[*FlameNode]map[string]*FlameNode{}
+
+	for _, s := range stacks {
+		root.Value += s.Value
+		node := root
+		for i, frame := range s.Stack {
+			children, ok := childIndex[node]
+			if !ok {
+				children = map[string]*FlameNode{}
+				childIndex[node] = children
+			}
+			child, ok := children[frame]
+			if !ok {
+				child = &FlameNode{Name: frame}
+				children[frame] = child
+				node.Children = append(node.Children, child)
+			}
+			child.Value += s.Value
+			if i == len(s.Stack)-1 {
+				child.Self += s.Value
+			}
+			node = child
+		}
+	}
+
+	sortFlameChildren(root)
+	return root
+}
+
+func sortFlameChildren(n *FlameNode) {
+	sort.SliceStable(n.Children, func(i, j int) bool {
+		if n.Children[i].Value != n.Children[j].Value {
+			return n.Children[i].Value > n.Children[j].Value
+		}
+		return n.Children[i].Name < n.Children[j].Name
+	})
+	for _, c := range n.Children {
+		sortFlameChildren(c)
+	}
+}

--- a/backend/app/services/profile_flamegraph_test.go
+++ b/backend/app/services/profile_flamegraph_test.go
@@ -1,0 +1,90 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/tracewayapp/traceway/backend/app/models"
+)
+
+func flameChild(n *FlameNode, name string) *FlameNode {
+	for _, c := range n.Children {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestFoldFlameGraph_SingleStack(t *testing.T) {
+	root := FoldFlameGraph([]models.ProfileStackValue{
+		{Stack: []string{"a", "b", "c"}, Value: 10},
+	})
+
+	if root.Name != "root" || root.Value != 10 {
+		t.Fatalf("root = %+v, want name=root value=10", root)
+	}
+	a := flameChild(root, "a")
+	if a == nil || a.Value != 10 || a.Self != 0 {
+		t.Fatalf("a = %+v, want value=10 self=0", a)
+	}
+	b := flameChild(a, "b")
+	if b == nil || b.Value != 10 || b.Self != 0 {
+		t.Fatalf("b = %+v, want value=10 self=0", b)
+	}
+	c := flameChild(b, "c")
+	if c == nil || c.Value != 10 || c.Self != 10 {
+		t.Fatalf("c = %+v, want value=10 self=10 (leaf carries self)", c)
+	}
+}
+
+func TestFoldFlameGraph_SharedPrefix(t *testing.T) {
+	root := FoldFlameGraph([]models.ProfileStackValue{
+		{Stack: []string{"a", "b"}, Value: 10},
+		{Stack: []string{"a", "c"}, Value: 5},
+	})
+
+	if root.Value != 15 {
+		t.Fatalf("root.Value = %d, want 15", root.Value)
+	}
+	a := flameChild(root, "a")
+	if a == nil || a.Value != 15 || a.Self != 0 {
+		t.Fatalf("a = %+v, want cumulative 15 self 0", a)
+	}
+	if b := flameChild(a, "b"); b == nil || b.Value != 10 || b.Self != 10 {
+		t.Fatalf("b = %+v, want value 10 self 10", b)
+	}
+	if c := flameChild(a, "c"); c == nil || c.Value != 5 || c.Self != 5 {
+		t.Fatalf("c = %+v, want value 5 self 5", c)
+	}
+}
+
+func TestFoldFlameGraph_PrefixIsAlsoLeaf(t *testing.T) {
+	root := FoldFlameGraph([]models.ProfileStackValue{
+		{Stack: []string{"a"}, Value: 3},
+		{Stack: []string{"a", "b"}, Value: 7},
+	})
+
+	a := flameChild(root, "a")
+	if a == nil || a.Value != 10 || a.Self != 3 {
+		t.Fatalf("a = %+v, want cumulative 10 self 3", a)
+	}
+	if b := flameChild(a, "b"); b == nil || b.Value != 7 || b.Self != 7 {
+		t.Fatalf("b = %+v, want value 7 self 7", b)
+	}
+}
+
+func TestFoldFlameGraph_ChildrenOrderedByValueDesc(t *testing.T) {
+	root := FoldFlameGraph([]models.ProfileStackValue{
+		{Stack: []string{"a"}, Value: 1},
+		{Stack: []string{"b"}, Value: 5},
+		{Stack: []string{"c"}, Value: 3},
+	})
+
+	var order []string
+	for _, c := range root.Children {
+		order = append(order, c.Name)
+	}
+	if len(order) != 3 || order[0] != "b" || order[1] != "c" || order[2] != "a" {
+		t.Fatalf("child order = %v, want [b c a] (value desc)", order)
+	}
+}


### PR DESCRIPTION
## What

PR 3 of the continuous-profiling series. Wires the merged profiling foundation (PR 1: pprof decoder, models, repository inserts, CH/SQLite migrations) to HTTP, completing the backend API the dashboard will consume in PR 4.

**Ingest** — `POST /api/profiles/ingest` accepts raw pprof bytes (gzip + client-token auth), decodes via `PprofDecoder`, and explodes into `profiling_stacks` / `profiling_samples` / `profiles`. `profiling.BuildRows` emits **one `profiles` row per profile type** (each with its own id and single-unit `TotalValue`/`SampleCount`); samples carry their type's profile id. Service / server / version come from query params (`?service=&serverName=&appVersion=`); `service` defaults to the project name.

**Query** — `POST /api/profiles/{grouped,series,flamegraph}`:
- `grouped` — list grouped by service + profile type (paginated).
- `series` — per-bucket trend.
- `flamegraph` — `GROUP BY stack_hash` joined to `profiling_stacks`, folded by `services.FoldFlameGraph` into a `{name,value,self,children}` tree.

**Aggregation semantics** — counters (cpu nanoseconds, alloc_space) sum across all instances; the `inuse_space` gauge takes the latest snapshot per server, so concurrent pods sum without a single server's history double-counting. Implemented for both SQLite (`!pgch`) and ClickHouse (`pgch`).

## Why

Traceway can't yet answer "where is my app spending CPU / allocating memory?". This lands the OTel-aligned, label-ready backend slice that the flame-graph UI consumes.

## Tests

`BuildRows` per-type mapping; flame-graph fold (shape/self/cumulative/ordering); repository grouped/series/flamegraph incl. cross-instance merge, label filter, gauge latest-per-server, and tied-`start_time` dedup; ingest controller (rows land, query-param/default service, garbage → 400). `go test ./...` green on the default (SQLite) build; `go build -tags pgch ./...` compiles the ClickHouse path. (Pre-existing `otelcontrollers/TestConvertTraces_Snapshot` failure is a Windows CRLF artifact, unrelated.)

## Notes / deliberate scope

- **No `/profiles/:profileId` detail endpoint.** With per-type rows and flame graphs keyed by *(service, type, range)*, a single-snapshot-by-id view is the wrong shape for the continuous-profiling UI; deferred to land with its PR 4 consumer if needed.
- **Docs** (CLAUDE.md endpoint/table tables, docs site) are deferred to PR 5 per the plan.
- **Follow-up:** the gauge **series** currently uses `AVG` per bucket (approximate, sparkline-only, no consumer until PR 4). A proper per-snapshot gauge series (consistent with the flame graph's latest-per-server) is tracked as a follow-up rather than rushed into this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)