### PR TITLE
feat(profiling): dashboard profiles UI + flame graph (PR 4)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,8 @@
 				"@fontsource/jetbrains-mono": "^5.2.8",
 				"@sveltejs/svelte-json-tree": "^2.2.1",
 				"@tracewayapp/svelte": "^1.0.2",
+				"d3-flame-graph": "^5.0.0",
+				"d3-selection": "^3.0.0",
 				"lucide-svelte": "^0.562.0",
 				"luxon": "^3.7.2",
 				"rrweb-player": "^2.0.0-alpha.18",
@@ -28,8 +30,10 @@
 				"@sveltejs/kit": "^2.49.1",
 				"@sveltejs/vite-plugin-svelte": "^6.2.1",
 				"@tailwindcss/vite": "^4.1.17",
+				"@testing-library/svelte": "^5.4.2",
 				"@types/d3-array": "^3.2.2",
 				"@types/d3-scale": "^4.0.9",
+				"@types/d3-selection": "^3.0.11",
 				"@types/d3-shape": "^3.1.7",
 				"@types/luxon": "^3.7.1",
 				"@types/node": "^22",
@@ -43,6 +47,7 @@
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-svelte": "^3.13.1",
 				"globals": "^16.5.0",
+				"jsdom": "^29.1.1",
 				"prettier": "^3.7.4",
 				"prettier-plugin-svelte": "^3.4.0",
 				"prettier-plugin-tailwindcss": "^0.7.2",
@@ -54,7 +59,247 @@
 				"tw-animate-css": "^1.4.0",
 				"typescript": "^5.9.3",
 				"typescript-eslint": "^8.48.1",
-				"vite": "^7.2.6"
+				"vite": "^7.2.6",
+				"vitest": "^4.1.9"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "5.1.11",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@csstools/css-calc": "^3.2.0",
+				"@csstools/css-color-parser": "^4.1.0",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.2.1",
+				"is-potential-custom-element-name": "^1.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/generational-cache": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+			"integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
+			"integrity": "sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.2.1"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+			"integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -675,6 +920,24 @@
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@floating-ui/core": {
@@ -1655,6 +1918,83 @@
 				"vite": "^5.2.0 || ^6 || ^7"
 			}
 		},
+		"node_modules/@testing-library/dom": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.3.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"picocolors": "1.1.1",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/aria-query": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"dequal": "^2.0.3"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@testing-library/svelte": {
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.4.2.tgz",
+			"integrity": "sha512-4o31E4HGo5BU5KwPkulNRocEden+7Tt9JYm9uhln5ajF7DULeyFA46BBWVfKJ8Ms9B3JmOFPTIiVamH7n3KpuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@testing-library/dom": "9.x.x || 10.x.x",
+				"@testing-library/svelte-core": "1.1.3"
+			},
+			"engines": {
+				"node": ">= 10"
+			},
+			"peerDependencies": {
+				"svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0",
+				"vite": "*",
+				"vitest": "*"
+			},
+			"peerDependenciesMeta": {
+				"vite": {
+					"optional": true
+				},
+				"vitest": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@testing-library/svelte-core": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.1.3.tgz",
+			"integrity": "sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0"
+			}
+		},
 		"node_modules/@tracewayapp/core": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@tracewayapp/core/-/core-1.0.2.tgz",
@@ -1685,6 +2025,24 @@
 			"resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-1.0.13.tgz",
 			"integrity": "sha512-5lYJP45Xllo4yE/RUBccBT32eBlRDbqN8r1/MIvQbKxW3aFqaYPCNgm8D5V20X4ShHcwvYWNlKg3liDh1MlBoA==",
 			"license": "MIT"
+		},
+		"node_modules/@types/aria-query": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
 		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
@@ -1723,6 +2081,13 @@
 				"@types/d3-time": "*"
 			}
 		},
+		"node_modules/@types/d3-selection": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+			"integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/d3-shape": {
 			"version": "3.1.7",
 			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
@@ -1737,6 +2102,13 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
 			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2026,6 +2398,119 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+			"integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+			"integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.9",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+			"integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+			"integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.9",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+			"integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/utils": "4.1.9",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+			"integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+			"integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.9",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/@xstate/fsm": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
@@ -2071,6 +2556,16 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2103,6 +2598,16 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2126,6 +2631,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6.0"
+			}
+		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
 			}
 		},
 		"node_modules/bits-ui": {
@@ -2172,6 +2687,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/chalk": {
@@ -2266,6 +2791,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -2291,6 +2823,20 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2308,7 +2854,6 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
 			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"internmap": "1 - 2"
@@ -2321,17 +2866,58 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
 			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dispatch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+			"integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-ease": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-flame-graph": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/d3-flame-graph/-/d3-flame-graph-5.0.0.tgz",
+			"integrity": "sha512-ALZQ4at8Dex8HCoj9D5p5TY6gLNEc2vAZAy+NKO/6GLEfhYJmGxYuRClO6RPoplndyOHxQTPipdlGeMggkjtnQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"d3-array": "^3.1.1",
+				"d3-dispatch": "^3.0.1",
+				"d3-ease": "^3.0.1",
+				"d3-format": "^3.0.1",
+				"d3-hierarchy": "^3.0.1",
+				"d3-scale": "^4.0.2",
+				"d3-selection": "^3.0.0",
+				"d3-transition": "^3.0.1"
 			}
 		},
 		"node_modules/d3-format": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
 			"integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-hierarchy": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+			"integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -2341,7 +2927,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
 			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"d3-color": "1 - 3"
@@ -2364,7 +2949,6 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
 			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"d3-array": "2.10.0 - 3",
@@ -2373,6 +2957,15 @@
 				"d3-time": "2.1.1 - 3",
 				"d3-time-format": "2 - 4"
 			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-selection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+			"license": "ISC",
 			"engines": {
 				"node": ">=12"
 			}
@@ -2394,7 +2987,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
 			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"d3-array": "2 - 3"
@@ -2407,13 +2999,54 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
 			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"d3-time": "1 - 3"
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/d3-timer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-transition": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+			"integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-dispatch": "1 - 3",
+				"d3-ease": "1 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"d3-selection": "2 - 3"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/debug": {
@@ -2433,6 +3066,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
@@ -2490,6 +3130,26 @@
 			"engines": {
 				"node": ">=10.13.0"
 			}
+		},
+		"node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/esbuild": {
 			"version": "0.27.2",
@@ -2755,6 +3415,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2763,6 +3433,16 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -2928,6 +3608,19 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.6.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2976,7 +3669,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
 			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -3005,6 +3697,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -3031,6 +3730,13 @@
 				"jiti": "lib/jiti-cli.mjs"
 			}
 		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/js-yaml": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3042,6 +3748,47 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "29.1.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+			"integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^5.1.11",
+				"@asamuzakjp/dom-selector": "^7.1.1",
+				"@bramus/specificity": "^2.4.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+				"@exodus/bytes": "^1.15.0",
+				"css-tree": "^3.2.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.3.5",
+				"parse5": "^8.0.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.1",
+				"undici": "^7.25.0",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.1",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/json-buffer": {
@@ -3406,6 +4153,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lru-cache": {
+			"version": "11.5.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/lucide-svelte": {
 			"version": "0.562.0",
 			"resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-0.562.0.tgz",
@@ -3442,6 +4199,13 @@
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
@@ -3514,6 +4278,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/obug": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3577,6 +4355,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3596,6 +4387,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -3868,6 +4666,34 @@
 				}
 			}
 		},
+		"node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3877,6 +4703,13 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/readdirp": {
 			"version": "4.1.2",
@@ -3890,6 +4723,16 @@
 			"funding": {
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/resolve-from": {
@@ -4027,6 +4870,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
 		"node_modules/semver": {
 			"version": "7.7.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -4070,6 +4926,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/sirv": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -4093,6 +4956,20 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
@@ -4268,6 +5145,13 @@
 				"svelte": "^5.30.2"
 			}
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tabbable": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.3.0.tgz",
@@ -4327,6 +5211,23 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4344,6 +5245,36 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tldts": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.4.tgz",
+			"integrity": "sha512-kFXFK7O4WPextIUAOk8qtnw9dxR9UIXP9CjuH1cTBVBZMDeQcUPgr/IazGiw1B0Yiw5L75gHLWeW4iD793r90g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.4.4"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.4.tgz",
+			"integrity": "sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -4352,6 +5283,32 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -4433,6 +5390,16 @@
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/undici": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/undici-types": {
@@ -4554,6 +5521,144 @@
 				}
 			}
 		},
+		"node_modules/vitest": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+			"integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.9",
+				"@vitest/mocker": "4.1.9",
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/runner": "4.1.9",
+				"@vitest/snapshot": "4.1.9",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.9",
+				"@vitest/browser-preview": "4.1.9",
+				"@vitest/browser-webdriverio": "4.1.9",
+				"@vitest/coverage-istanbul": "4.1.9",
+				"@vitest/coverage-v8": "4.1.9",
+				"@vitest/ui": "4.1.9",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4570,6 +5675,23 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4579,6 +5701,23 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
-		"lint": "prettier --check . && eslint ."
+		"lint": "prettier --check . && eslint .",
+		"test": "svelte-kit sync && vitest run",
+		"test:watch": "svelte-kit sync && vitest"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.4.0",
@@ -23,8 +25,10 @@
 		"@sveltejs/kit": "^2.49.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@tailwindcss/vite": "^4.1.17",
+		"@testing-library/svelte": "^5.4.2",
 		"@types/d3-array": "^3.2.2",
 		"@types/d3-scale": "^4.0.9",
+		"@types/d3-selection": "^3.0.11",
 		"@types/d3-shape": "^3.1.7",
 		"@types/luxon": "^3.7.1",
 		"@types/node": "^22",
@@ -38,6 +42,7 @@
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.13.1",
 		"globals": "^16.5.0",
+		"jsdom": "^29.1.1",
 		"prettier": "^3.7.4",
 		"prettier-plugin-svelte": "^3.4.0",
 		"prettier-plugin-tailwindcss": "^0.7.2",
@@ -49,13 +54,16 @@
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.48.1",
-		"vite": "^7.2.6"
+		"vite": "^7.2.6",
+		"vitest": "^4.1.9"
 	},
 	"dependencies": {
 		"@fontsource/ibm-plex-mono": "^5.2.7",
 		"@fontsource/jetbrains-mono": "^5.2.8",
 		"@sveltejs/svelte-json-tree": "^2.2.1",
 		"@tracewayapp/svelte": "^1.0.2",
+		"d3-flame-graph": "^5.0.0",
+		"d3-selection": "^3.0.0",
 		"lucide-svelte": "^0.562.0",
 		"luxon": "^3.7.2",
 		"rrweb-player": "^2.0.0-alpha.18",

--- a/frontend/src/d3-flame-graph.d.ts
+++ b/frontend/src/d3-flame-graph.d.ts
@@ -1,0 +1,31 @@
+declare module 'd3-flame-graph' {
+	export interface FlameGraphNode {
+		name: string;
+		value: number;
+		self?: number;
+		children?: FlameGraphNode[];
+	}
+
+	export interface FlameGraph {
+		(selection: unknown): void;
+		width(value: number): FlameGraph;
+		height(value: number): FlameGraph;
+		cellHeight(value: number): FlameGraph;
+		minFrameSize(value: number): FlameGraph;
+		transitionDuration(value: number): FlameGraph;
+		inverted(value: boolean): FlameGraph;
+		sort(value: boolean): FlameGraph;
+		selfValue(value: boolean): FlameGraph;
+		setColorMapper(fn: (node: unknown, originalColor: string) => string): FlameGraph;
+		label(fn: (node: { data: FlameGraphNode }) => string): FlameGraph;
+		onClick(fn: (node: unknown) => void): FlameGraph;
+		resetZoom(): void;
+		search(term: string): void;
+		clear(): void;
+		destroy(): void;
+	}
+
+	export default function flamegraph(): FlameGraph;
+	export function colorMapper(node: unknown): string;
+	export function tooltip(): unknown;
+}

--- a/frontend/src/lib/components/app-sidebar.svelte
+++ b/frontend/src/lib/components/app-sidebar.svelte
@@ -10,6 +10,7 @@
 		ChartNoAxesGantt,
 		FileText,
 		Film,
+		Flame,
 		Gauge,
 		ListEnd,
 		Settings,
@@ -30,7 +31,7 @@
 		external?: boolean;
 	}
 
-	const hiddenForFrontend = new Set(['Dashboard', 'Logs', 'Endpoints', 'Tasks', 'Metrics', 'AI Traces']);
+	const hiddenForFrontend = new Set(['Dashboard', 'Logs', 'Endpoints', 'Tasks', 'Profiles', 'Metrics', 'AI Traces']);
 	const hiddenForCloudflare = new Set(['Metrics']);
 	// Items that only make sense for frontend (browser) projects — dropped from
 	// the sidebar for any other framework, so a Go backend project doesn't
@@ -43,6 +44,7 @@
 		{ Icon: FileText, href: '/logs', title: 'Logs', stickyParams: ['preset', 'from', 'to'] },
 		{ Icon: Gauge, href: '/endpoints', title: 'Endpoints', stickyParams: ['preset', 'from', 'to'] },
 		{ Icon: ListEnd, href: '/tasks', title: 'Tasks', stickyParams: ['preset', 'from', 'to'] },
+		{ Icon: Flame, href: '/profiles', title: 'Profiles', stickyParams: ['preset', 'from', 'to'] },
 		{ Icon: Film, href: '/sessions', title: 'Sessions', stickyParams: ['preset', 'from', 'to'] },
 		{ Icon: Workflow, href: '/ai-traces', title: 'AI Traces', stickyParams: ['preset', 'from', 'to'] },
 		{

--- a/frontend/src/lib/components/profiles/flame-graph.svelte
+++ b/frontend/src/lib/components/profiles/flame-graph.svelte
@@ -1,0 +1,121 @@
+<script module lang="ts">
+	import { formatProfileValue } from '$lib/utils/profile-format';
+
+	export function flameTooltipLabel(
+		name: string,
+		value: number,
+		total: number,
+		type: string
+	): string {
+		const pct = total > 0 ? (value / total) * 100 : 0;
+		const pctStr = Number(pct.toFixed(1)).toString();
+		return `${name} — ${formatProfileValue(type, value)} (${pctStr}%)`;
+	}
+</script>
+
+<script lang="ts">
+	import flamegraph, { type FlameGraphNode } from 'd3-flame-graph';
+	import { select } from 'd3-selection';
+
+	interface Props {
+		data: FlameGraphNode | null;
+		type: string;
+	}
+
+	let { data, type }: Props = $props();
+
+	let container = $state<HTMLDivElement>();
+	let width = $state(0);
+
+	$effect(() => {
+		const el = container;
+		if (!el || typeof ResizeObserver === 'undefined') return;
+		const observer = new ResizeObserver((entries) => {
+			width = entries[0].contentRect.width;
+		});
+		observer.observe(el);
+		return () => observer.disconnect();
+	});
+
+	$effect(() => {
+		const el = container;
+		if (!el || !data) return;
+
+		const total = data.value || 0;
+		const chart = flamegraph()
+			.width(width || el.clientWidth || 960)
+			.cellHeight(20)
+			.minFrameSize(1)
+			.transitionDuration(200)
+			.sort(true)
+			.selfValue(false)
+			.label((d) => flameTooltipLabel(d.data.name, d.data.value, total, type));
+
+		select(el).datum(data).call(chart);
+
+		return () => {
+			try {
+				chart.destroy();
+			} catch {
+				// destroy() can throw if the chart never finished mounting; the
+				// unconditional clear below is the real teardown either way.
+			}
+			select(el).selectAll('*').remove();
+		};
+	});
+</script>
+
+{#if !data}
+	<div
+		class="flex h-48 items-center justify-center rounded-md border text-sm text-muted-foreground"
+	>
+		No flame graph data for this range.
+	</div>
+{:else}
+	<div bind:this={container} class="flame-graph w-full"></div>
+{/if}
+
+<style>
+	:global(.flame-graph .d3-flame-graph rect) {
+		stroke: var(--background);
+		stroke-width: 0.5;
+		fill-opacity: 0.85;
+	}
+
+	:global(.flame-graph .d3-flame-graph rect:hover) {
+		stroke: var(--ring);
+		stroke-width: 1;
+		cursor: pointer;
+	}
+
+	:global(.flame-graph .d3-flame-graph-label) {
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		overflow: hidden;
+		font-size: 12px;
+		font-family: inherit;
+		margin-left: 4px;
+		margin-right: 4px;
+		line-height: 1.5;
+		font-weight: 400;
+		color: #fff;
+		text-align: left;
+	}
+
+	:global(.flame-graph .d3-flame-graph .fade) {
+		opacity: 0.5 !important;
+	}
+
+	:global(.d3-flame-graph-tip) {
+		background: var(--popover);
+		color: var(--popover-foreground);
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		padding: 6px 10px;
+		min-width: 250px;
+		text-align: left;
+		font-family: inherit;
+		font-size: 12px;
+		z-index: 10;
+	}
+</style>

--- a/frontend/src/lib/components/profiles/flame-graph.svelte
+++ b/frontend/src/lib/components/profiles/flame-graph.svelte
@@ -42,6 +42,7 @@
 		if (!el || !data) return;
 
 		const total = data.value || 0;
+		const currentType = type;
 		const chart = flamegraph()
 			.width(width || el.clientWidth || 960)
 			.cellHeight(20)
@@ -49,7 +50,7 @@
 			.transitionDuration(200)
 			.sort(true)
 			.selfValue(false)
-			.label((d) => flameTooltipLabel(d.data.name, d.data.value, total, type));
+			.label((d) => flameTooltipLabel(d.data.name, d.data.value, total, currentType));
 
 		select(el).datum(data).call(chart);
 

--- a/frontend/src/lib/components/profiles/flame-graph.test.ts
+++ b/frontend/src/lib/components/profiles/flame-graph.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+const flamegraphSpy = vi.hoisted(() => vi.fn());
+const datumSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('d3-flame-graph', () => {
+	const chart = new Proxy(() => chart, { get: () => () => chart }) as never;
+	return { default: () => (flamegraphSpy(), chart), colorMapper: () => '', tooltip: () => ({}) };
+});
+
+vi.mock('d3-selection', () => {
+	const sel: Record<string, unknown> = {};
+	sel.datum = (d: unknown) => (datumSpy(d), sel);
+	sel.call = () => sel;
+	sel.selectAll = () => sel;
+	sel.remove = () => sel;
+	sel.html = () => sel;
+	sel.node = () => null;
+	return { select: () => sel };
+});
+
+import FlameGraph, { flameTooltipLabel } from './flame-graph.svelte';
+import { CPU_NANOS } from '$lib/utils/profile-format';
+
+const tree = {
+	name: 'root',
+	value: 100,
+	self: 0,
+	children: [{ name: 'main.work', value: 60, self: 60, children: [] }]
+};
+
+describe('flameTooltipLabel', () => {
+	it('formats name, value and percentage of total', () => {
+		expect(flameTooltipLabel('main.work', 1_500_000, 4_000_000, CPU_NANOS)).toBe(
+			'main.work — 1.5 ms (37.5%)'
+		);
+	});
+
+	it('renders 0% instead of NaN when the total is zero', () => {
+		expect(flameTooltipLabel('main.work', 10, 0, CPU_NANOS)).toBe('main.work — 10 ns (0%)');
+	});
+});
+
+describe('FlameGraph component', () => {
+	beforeEach(() => {
+		flamegraphSpy.mockClear();
+		datumSpy.mockClear();
+	});
+
+	it('shows an empty state and does not render a chart when data is null', () => {
+		const { getByText } = render(FlameGraph, { props: { data: null, type: CPU_NANOS } });
+		expect(getByText(/no flame graph data/i)).toBeTruthy();
+		expect(flamegraphSpy).not.toHaveBeenCalled();
+	});
+
+	it('renders the d3 flame graph with the provided tree', () => {
+		render(FlameGraph, { props: { data: tree, type: CPU_NANOS } });
+		expect(flamegraphSpy).toHaveBeenCalled();
+		expect(datumSpy).toHaveBeenCalledWith(tree);
+	});
+
+	it('re-renders when the data prop changes', async () => {
+		const { rerender } = render(FlameGraph, { props: { data: tree, type: CPU_NANOS } });
+		datumSpy.mockClear();
+		const next = { name: 'root', value: 50, self: 0, children: [] };
+		await rerender({ data: next, type: CPU_NANOS });
+		expect(datumSpy).toHaveBeenCalledWith(next);
+	});
+});

--- a/frontend/src/lib/utils/profile-format.test.ts
+++ b/frontend/src/lib/utils/profile-format.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+	CPU_NANOS,
+	HEAP_INUSE,
+	HEAP_ALLOC,
+	getProfileTypeMeta,
+	formatProfileValue,
+	defaultProfileType
+} from './profile-format';
+
+describe('getProfileTypeMeta', () => {
+	it('returns meta for the CPU type', () => {
+		const meta = getProfileTypeMeta(CPU_NANOS);
+		expect(meta).toMatchObject({ category: 'cpu', unit: 'nanoseconds', isGauge: false });
+		expect(meta?.label).toBeTruthy();
+	});
+
+	it('marks heap in-use as a gauge', () => {
+		const meta = getProfileTypeMeta(HEAP_INUSE);
+		expect(meta).toMatchObject({ category: 'heap', unit: 'bytes', isGauge: true });
+	});
+
+	it('marks heap alloc as a counter (not a gauge)', () => {
+		const meta = getProfileTypeMeta(HEAP_ALLOC);
+		expect(meta).toMatchObject({ category: 'heap', unit: 'bytes', isGauge: false });
+	});
+
+	it('returns undefined for an unknown type', () => {
+		expect(getProfileTypeMeta('go:profile_mutex:contentions')).toBeUndefined();
+	});
+});
+
+describe('formatProfileValue', () => {
+	it('formats CPU nanoseconds across magnitudes', () => {
+		expect(formatProfileValue(CPU_NANOS, 500)).toBe('500 ns');
+		expect(formatProfileValue(CPU_NANOS, 1_500)).toBe('1.5 µs');
+		expect(formatProfileValue(CPU_NANOS, 1_500_000)).toBe('1.5 ms');
+		expect(formatProfileValue(CPU_NANOS, 2_000_000_000)).toBe('2 s');
+		expect(formatProfileValue(CPU_NANOS, 0)).toBe('0 ns');
+	});
+
+	it('formats heap bytes across magnitudes', () => {
+		expect(formatProfileValue(HEAP_INUSE, 512)).toBe('512 B');
+		expect(formatProfileValue(HEAP_INUSE, 1024)).toBe('1 KB');
+		expect(formatProfileValue(HEAP_ALLOC, 1_048_576)).toBe('1 MB');
+		expect(formatProfileValue(HEAP_INUSE, 0)).toBe('0 B');
+	});
+
+	it('falls back to a localized number for unknown types', () => {
+		expect(formatProfileValue('go:profile_mystery:units', 1234)).toBe((1234).toLocaleString());
+	});
+});
+
+describe('defaultProfileType', () => {
+	it('prefers the CPU type when available', () => {
+		expect(defaultProfileType([HEAP_INUSE, CPU_NANOS, HEAP_ALLOC])).toBe(CPU_NANOS);
+	});
+
+	it('falls back to the first available type when there is no CPU type', () => {
+		expect(defaultProfileType([HEAP_ALLOC, HEAP_INUSE])).toBe(HEAP_ALLOC);
+	});
+
+	it('returns an empty string when nothing is available', () => {
+		expect(defaultProfileType([])).toBe('');
+	});
+});

--- a/frontend/src/lib/utils/profile-format.ts
+++ b/frontend/src/lib/utils/profile-format.ts
@@ -1,0 +1,56 @@
+export const CPU_NANOS = 'go:profile_cpu:nanoseconds';
+export const HEAP_INUSE = 'go:profile_heap:inuse_space';
+export const HEAP_ALLOC = 'go:profile_heap:alloc_space';
+
+export type ProfileCategory = 'cpu' | 'heap';
+export type ProfileUnit = 'nanoseconds' | 'bytes';
+
+export interface ProfileTypeMeta {
+	type: string;
+	label: string;
+	category: ProfileCategory;
+	unit: ProfileUnit;
+	isGauge: boolean;
+}
+
+export const PROFILE_TYPES: ProfileTypeMeta[] = [
+	{ type: CPU_NANOS, label: 'CPU Time', category: 'cpu', unit: 'nanoseconds', isGauge: false },
+	{ type: HEAP_INUSE, label: 'Heap In-Use', category: 'heap', unit: 'bytes', isGauge: true },
+	{ type: HEAP_ALLOC, label: 'Heap Allocations', category: 'heap', unit: 'bytes', isGauge: false }
+];
+
+const TYPE_INDEX = new Map(PROFILE_TYPES.map((meta) => [meta.type, meta]));
+
+export function getProfileTypeMeta(type: string): ProfileTypeMeta | undefined {
+	return TYPE_INDEX.get(type);
+}
+
+function trim(value: number): string {
+	return Number(value.toFixed(2)).toString();
+}
+
+function formatNanoseconds(ns: number): string {
+	if (ns < 1_000) return `${trim(ns)} ns`;
+	if (ns < 1_000_000) return `${trim(ns / 1_000)} µs`;
+	if (ns < 1_000_000_000) return `${trim(ns / 1_000_000)} ms`;
+	return `${trim(ns / 1_000_000_000)} s`;
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${trim(bytes)} B`;
+	if (bytes < 1024 ** 2) return `${trim(bytes / 1024)} KB`;
+	if (bytes < 1024 ** 3) return `${trim(bytes / 1024 ** 2)} MB`;
+	return `${trim(bytes / 1024 ** 3)} GB`;
+}
+
+export function formatProfileValue(type: string, value: number): string {
+	const meta = getProfileTypeMeta(type);
+	if (meta?.unit === 'nanoseconds') return formatNanoseconds(value);
+	if (meta?.unit === 'bytes') return formatBytes(value);
+	return value.toLocaleString();
+}
+
+export function defaultProfileType(availableTypes: string[]): string {
+	if (availableTypes.includes(CPU_NANOS)) return CPU_NANOS;
+	return availableTypes[0] ?? '';
+}

--- a/frontend/src/routes/profiles/+page.svelte
+++ b/frontend/src/routes/profiles/+page.svelte
@@ -1,0 +1,327 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { api } from '$lib/api';
+	import { formatRelativeTime, toUTCISO, calendarDateTimeToLuxon } from '$lib/utils/formatters';
+	import { formatProfileValue, getProfileTypeMeta } from '$lib/utils/profile-format';
+	import { getTimezone } from '$lib/state/timezone.svelte';
+	import * as Table from '$lib/components/ui/table';
+	import { LoadingCircle } from '$lib/components/ui/loading-circle';
+	import { TracewayTableHeader } from '$lib/components/ui/traceway-table-header';
+	import { TableEmptyState } from '$lib/components/ui/table-empty-state';
+	import { PaginationFooter } from '$lib/components/ui/pagination-footer';
+	import { TimeRangePicker } from '$lib/components/ui/time-range-picker';
+	import { CalendarDate } from '@internationalized/date';
+	import { projectsState } from '$lib/state/projects.svelte';
+	import { createRowClickHandler } from '$lib/utils/navigation';
+	import { resolve } from '$app/paths';
+	import PageHeader from '$lib/components/issues/page-header.svelte';
+	import {
+		getTimeRangeFromPreset,
+		dateToCalendarDate,
+		dateToTimeString,
+		parseTimeRangeFromUrl,
+		getResolvedTimeRange,
+		updateUrl
+	} from '$lib/utils/url-params';
+	import {
+		getSortState,
+		setSortState,
+		handleSortClick,
+		type SortDirection
+	} from '$lib/utils/sort-storage';
+
+	const timezone = $derived(getTimezone());
+
+	type ProfileGroup = {
+		serviceName: string;
+		type: string;
+		profileCount: number;
+		sampleCount: number;
+		totalValue: number;
+		lastSeen: string;
+	};
+
+	type SortField = 'profile_count' | 'sample_count' | 'total_value' | 'last_seen';
+
+	let groups = $state<ProfileGroup[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	let page = $state(1);
+	let pageSize = $state(50);
+	let total = $state(0);
+	let totalPages = $state(0);
+
+	const initialUrlParams = parseTimeRangeFromUrl(timezone);
+	const initialRange = getResolvedTimeRange(initialUrlParams, timezone);
+
+	let selectedPreset = $state<string | null>(initialUrlParams.preset);
+	let fromDate = $state<CalendarDate>(dateToCalendarDate(initialRange.from, timezone));
+	let toDate = $state<CalendarDate>(dateToCalendarDate(initialRange.to, timezone));
+	let fromTime = $state(dateToTimeString(initialRange.from, timezone));
+	let toTime = $state(dateToTimeString(initialRange.to, timezone));
+
+	function updateTimeRangeUrl(pushToHistory = true) {
+		updateUrl(
+			selectedPreset
+				? { preset: selectedPreset }
+				: { from: getFromDateTimeUTC(), to: getToDateTimeUTC() },
+			{ pushToHistory }
+		);
+	}
+
+	function handlePopState() {
+		const urlParams = parseTimeRangeFromUrl(timezone);
+		const range = getResolvedTimeRange(urlParams, timezone);
+
+		selectedPreset = urlParams.preset;
+		fromDate = dateToCalendarDate(range.from, timezone);
+		fromTime = dateToTimeString(range.from, timezone);
+		toDate = dateToCalendarDate(range.to, timezone);
+		toTime = dateToTimeString(range.to, timezone);
+
+		page = 1;
+		loadData(false);
+	}
+
+	const SORT_STORAGE_KEY = 'profiles';
+	const initialSort = getSortState(SORT_STORAGE_KEY, { field: 'total_value', direction: 'desc' });
+	let orderBy = $state<SortField>(initialSort.field as SortField);
+	let sortDirection = $state<SortDirection>(initialSort.direction);
+
+	function getFromDateTimeUTC(): string {
+		const [hour, minute] = (fromTime || '00:00').split(':').map(Number);
+		const dt = calendarDateTimeToLuxon(
+			{ year: fromDate.year, month: fromDate.month, day: fromDate.day, hour, minute },
+			timezone
+		);
+		return toUTCISO(dt);
+	}
+
+	function getToDateTimeUTC(): string {
+		const [hour, minute] = (toTime || '23:59').split(':').map(Number);
+		const dt = calendarDateTimeToLuxon(
+			{ year: toDate.year, month: toDate.month, day: toDate.day, hour, minute },
+			timezone
+		).endOf('minute');
+		return toUTCISO(dt);
+	}
+
+	function handleTimeRangeChange(
+		from: { date: CalendarDate; time: string },
+		to: { date: CalendarDate; time: string },
+		preset: string | null
+	) {
+		fromDate = from.date;
+		fromTime = from.time;
+		toDate = to.date;
+		toTime = to.time;
+		selectedPreset = preset;
+		page = 1;
+		loadData(true);
+	}
+
+	function formatCount(count: number): string {
+		if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}m`;
+		if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+		return count.toLocaleString();
+	}
+
+	function typeLabel(type: string): string {
+		return getProfileTypeMeta(type)?.label ?? type;
+	}
+
+	function detailHref(group: ProfileGroup): string {
+		return `${resolve(`/profiles/${encodeURIComponent(group.serviceName)}`)}?type=${encodeURIComponent(group.type)}`;
+	}
+
+	async function loadData(pushToHistory = true) {
+		loading = true;
+		error = '';
+
+		if (selectedPreset) {
+			const range = getTimeRangeFromPreset(selectedPreset, timezone);
+			fromDate = dateToCalendarDate(range.from, timezone);
+			toDate = dateToCalendarDate(range.to, timezone);
+			fromTime = dateToTimeString(range.from, timezone);
+			toTime = dateToTimeString(range.to, timezone);
+		}
+
+		updateTimeRangeUrl(pushToHistory);
+
+		try {
+			const requestBody = {
+				fromDate: getFromDateTimeUTC(),
+				toDate: getToDateTimeUTC(),
+				orderBy,
+				sortDirection,
+				pagination: { page, pageSize }
+			};
+
+			const response = await api.post('/profiles/grouped', requestBody, {
+				projectId: projectsState.currentProjectId ?? undefined
+			});
+
+			groups = response.data || [];
+			total = response.pagination.total;
+			totalPages = response.pagination.totalPages;
+		} catch (e: any) {
+			console.error(e);
+			error = e.message || 'Failed to load data';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function handlePageChange(newPage: number) {
+		if (newPage >= 1 && newPage <= totalPages) {
+			page = newPage;
+			loadData(false);
+		}
+	}
+
+	function handlePageSizeChange(newPageSize: number) {
+		pageSize = newPageSize;
+		page = 1;
+		loadData(false);
+	}
+
+	function handleSort(field: SortField) {
+		const newSort = handleSortClick(field, orderBy, sortDirection);
+		orderBy = newSort.field as SortField;
+		sortDirection = newSort.direction;
+		setSortState(SORT_STORAGE_KEY, newSort);
+		page = 1;
+		loadData(false);
+	}
+
+	onMount(() => {
+		window.addEventListener('popstate', handlePopState);
+		loadData(false);
+	});
+
+	onDestroy(() => {
+		if (typeof window !== 'undefined') {
+			window.removeEventListener('popstate', handlePopState);
+		}
+	});
+</script>
+
+<div class="space-y-4">
+	<div class="flex flex-col gap-4 sm:flex-row sm:justify-between">
+		<PageHeader title="Profiles" />
+
+		<div class="flex flex-col">
+			<TimeRangePicker
+				bind:fromDate
+				bind:toDate
+				bind:fromTime
+				bind:toTime
+				bind:preset={selectedPreset}
+				onApply={handleTimeRangeChange}
+			/>
+		</div>
+	</div>
+
+	<div class="overflow-hidden rounded-md border">
+		<Table.Root>
+			{#if loading}
+				<Table.Body>
+					<Table.Row>
+						<Table.Cell colspan={6} class="h-48">
+							<div class="flex h-full items-center justify-center">
+								<LoadingCircle size="xlg" />
+							</div>
+						</Table.Cell>
+					</Table.Row>
+				</Table.Body>
+			{:else if error}
+				<Table.Body>
+					<Table.Row>
+						<Table.Cell colspan={6} class="h-24 text-center text-red-500">{error}</Table.Cell>
+					</Table.Row>
+				</Table.Body>
+			{:else if groups.length === 0}
+				<Table.Body>
+					<TableEmptyState colspan={6} message="No profile data received yet" />
+				</Table.Body>
+			{:else}
+				<Table.Header>
+					<Table.Row>
+						<TracewayTableHeader label="Service" tooltip="The service that emitted the profile" />
+						<TracewayTableHeader
+							label="Type"
+							tooltip="The profile type (CPU time or heap memory)"
+						/>
+						<TracewayTableHeader
+							label="Profiles"
+							tooltip="Number of profiles collected in the range"
+							sortField="profile_count"
+							currentSortField={orderBy}
+							{sortDirection}
+							onSort={(field) => handleSort(field as SortField)}
+							class="w-[110px]"
+						/>
+						<TracewayTableHeader
+							label="Samples"
+							tooltip="Total samples across all profiles"
+							sortField="sample_count"
+							currentSortField={orderBy}
+							{sortDirection}
+							onSort={(field) => handleSort(field as SortField)}
+							class="w-[110px]"
+						/>
+						<TracewayTableHeader
+							label="Total"
+							tooltip="Aggregate value (CPU time or bytes) over the range"
+							sortField="total_value"
+							currentSortField={orderBy}
+							{sortDirection}
+							onSort={(field) => handleSort(field as SortField)}
+							class="w-[120px]"
+						/>
+						<TracewayTableHeader
+							label="Last Seen"
+							tooltip="When this service last reported this profile type"
+							sortField="last_seen"
+							currentSortField={orderBy}
+							{sortDirection}
+							onSort={(field) => handleSort(field as SortField)}
+							class="w-[110px]"
+						/>
+					</Table.Row>
+				</Table.Header>
+				<Table.Body>
+					{#each groups as group (group.serviceName + group.type)}
+						<Table.Row
+							class="cursor-pointer hover:bg-muted/50"
+							onclick={createRowClickHandler(detailHref(group), 'preset', 'from', 'to')}
+						>
+							<Table.Cell class="font-mono text-sm">{group.serviceName}</Table.Cell>
+							<Table.Cell class="text-sm">{typeLabel(group.type)}</Table.Cell>
+							<Table.Cell class="tabular-nums">{formatCount(group.profileCount)}</Table.Cell>
+							<Table.Cell class="tabular-nums">{formatCount(group.sampleCount)}</Table.Cell>
+							<Table.Cell class="font-mono text-sm tabular-nums">
+								{formatProfileValue(group.type, group.totalValue)}
+							</Table.Cell>
+							<Table.Cell class="text-sm text-muted-foreground">
+								{formatRelativeTime(group.lastSeen, timezone)}
+							</Table.Cell>
+						</Table.Row>
+					{/each}
+				</Table.Body>
+			{/if}
+		</Table.Root>
+	</div>
+
+	<PaginationFooter
+		currentPage={page}
+		{totalPages}
+		{pageSize}
+		totalItems={total}
+		onPageChange={handlePageChange}
+		onPageSizeChange={handlePageSizeChange}
+		{loading}
+		itemLabel="profile"
+	/>
+</div>

--- a/frontend/src/routes/profiles/+page.svelte
+++ b/frontend/src/routes/profiles/+page.svelte
@@ -292,7 +292,7 @@
 					</Table.Row>
 				</Table.Header>
 				<Table.Body>
-					{#each groups as group (group.serviceName + group.type)}
+					{#each groups as group (group.serviceName + '::' + group.type)}
 						<Table.Row
 							class="cursor-pointer hover:bg-muted/50"
 							onclick={createRowClickHandler(detailHref(group), 'preset', 'from', 'to')}

--- a/frontend/src/routes/profiles/[service]/+page.svelte
+++ b/frontend/src/routes/profiles/[service]/+page.svelte
@@ -46,7 +46,10 @@
 	let error = $state('');
 	let notFound = $state(false);
 
-	let activeType = $state(data.type ?? defaultProfileType(PROFILE_TYPES.map((t) => t.type)));
+	const knownTypes = PROFILE_TYPES.map((t) => t.type);
+	let activeType = $state(
+		data.type && knownTypes.includes(data.type) ? data.type : defaultProfileType(knownTypes)
+	);
 
 	function getInitialRange(): { preset: string | null; from: Date; to: Date } {
 		if (data.preset && presetMinutes[data.preset]) {

--- a/frontend/src/routes/profiles/[service]/+page.svelte
+++ b/frontend/src/routes/profiles/[service]/+page.svelte
@@ -1,0 +1,279 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api } from '$lib/api';
+	import { Button } from '$lib/components/ui/button';
+	import { LoadingCircle } from '$lib/components/ui/loading-circle';
+	import { TimeRangePicker } from '$lib/components/ui/time-range-picker';
+	import { ErrorDisplay } from '$lib/components/ui/error-display';
+	import * as Tabs from '$lib/components/ui/tabs';
+	import { ArrowLeft } from '@lucide/svelte';
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { projectsState } from '$lib/state/projects.svelte';
+	import PageHeader from '$lib/components/issues/page-header.svelte';
+	import FlameGraph from '$lib/components/profiles/flame-graph.svelte';
+	import { CalendarDate } from '@internationalized/date';
+	import {
+		PROFILE_TYPES,
+		defaultProfileType,
+		formatProfileValue,
+		getProfileTypeMeta,
+		type ProfileTypeMeta
+	} from '$lib/utils/profile-format';
+	import {
+		presetMinutes,
+		getTimeRangeFromPreset,
+		parseTimeRangeFromUrl,
+		getResolvedTimeRange,
+		dateToCalendarDate,
+		dateToTimeString,
+		updateUrl
+	} from '$lib/utils/url-params';
+	import { getTimezone } from '$lib/state/timezone.svelte';
+	import { toUTCISO, calendarDateTimeToLuxon, parseISO } from '$lib/utils/formatters';
+	import type { FlameGraphNode } from 'd3-flame-graph';
+
+	const timezone = $derived(getTimezone());
+
+	type SeriesPoint = { timestamp: string; value: number };
+
+	let { data } = $props();
+
+	let flameData = $state<FlameGraphNode | null>(null);
+	let series = $state<SeriesPoint[]>([]);
+	let totalValue = $state(0);
+	let loading = $state(true);
+	let error = $state('');
+	let notFound = $state(false);
+
+	let activeType = $state(data.type ?? defaultProfileType(PROFILE_TYPES.map((t) => t.type)));
+
+	function getInitialRange(): { preset: string | null; from: Date; to: Date } {
+		if (data.preset && presetMinutes[data.preset]) {
+			const range = getTimeRangeFromPreset(data.preset, timezone);
+			return { preset: data.preset, from: range.from, to: range.to };
+		}
+		if (data.from && data.to) {
+			const fromDt = parseISO(data.from, timezone);
+			const toDt = parseISO(data.to, timezone);
+			if (fromDt.isValid && toDt.isValid) {
+				return { preset: null, from: fromDt.toJSDate(), to: toDt.toJSDate() };
+			}
+		}
+		const range = getTimeRangeFromPreset('24h', timezone);
+		return { preset: '24h', from: range.from, to: range.to };
+	}
+
+	const initialRange = getInitialRange();
+
+	let selectedPreset = $state<string | null>(initialRange.preset);
+	let fromDate = $state<CalendarDate>(dateToCalendarDate(initialRange.from, timezone));
+	let toDate = $state<CalendarDate>(dateToCalendarDate(initialRange.to, timezone));
+	let fromTime = $state(dateToTimeString(initialRange.from, timezone));
+	let toTime = $state(dateToTimeString(initialRange.to, timezone));
+
+	const activeMeta = $derived<ProfileTypeMeta | undefined>(getProfileTypeMeta(activeType));
+	const seriesPeak = $derived(series.reduce((max, p) => Math.max(max, p.value), 0));
+
+	function updateUrlParams(pushToHistory = true) {
+		const params: Record<string, string | undefined> = selectedPreset
+			? { preset: selectedPreset }
+			: { from: getFromDateTimeUTC(), to: getToDateTimeUTC() };
+		params.type = activeType;
+		updateUrl(params, { pushToHistory });
+	}
+
+	function getFromDateTimeUTC(): string {
+		const [hour, minute] = (fromTime || '00:00').split(':').map(Number);
+		const dt = calendarDateTimeToLuxon(
+			{ year: fromDate.year, month: fromDate.month, day: fromDate.day, hour, minute },
+			timezone
+		);
+		return toUTCISO(dt);
+	}
+
+	function getToDateTimeUTC(): string {
+		const [hour, minute] = (toTime || '23:59').split(':').map(Number);
+		const dt = calendarDateTimeToLuxon(
+			{ year: toDate.year, month: toDate.month, day: toDate.day, hour, minute },
+			timezone
+		).endOf('minute');
+		return toUTCISO(dt);
+	}
+
+	function intervalMinutes(fromIso: string, toIso: string): number {
+		const spanMinutes = Math.max(
+			1,
+			Math.round((new Date(toIso).getTime() - new Date(fromIso).getTime()) / 60_000)
+		);
+		return Math.max(1, Math.round(spanMinutes / 60));
+	}
+
+	function handleTimeRangeChange(
+		from: { date: CalendarDate; time: string },
+		to: { date: CalendarDate; time: string },
+		preset: string | null
+	) {
+		fromDate = from.date;
+		fromTime = from.time;
+		toDate = to.date;
+		toTime = to.time;
+		selectedPreset = preset;
+		loadData(true);
+	}
+
+	function handleTypeChange(type: string) {
+		activeType = type;
+		loadData(true);
+	}
+
+	async function loadData(pushToHistory = true) {
+		loading = true;
+		error = '';
+		notFound = false;
+
+		if (selectedPreset) {
+			const range = getTimeRangeFromPreset(selectedPreset, timezone);
+			fromDate = dateToCalendarDate(range.from, timezone);
+			toDate = dateToCalendarDate(range.to, timezone);
+			fromTime = dateToTimeString(range.from, timezone);
+			toTime = dateToTimeString(range.to, timezone);
+		}
+
+		updateUrlParams(pushToHistory);
+
+		const fromIso = getFromDateTimeUTC();
+		const toIso = getToDateTimeUTC();
+		const body = {
+			fromDate: fromIso,
+			toDate: toIso,
+			serviceName: data.service,
+			type: activeType
+		};
+
+		try {
+			const [tree, points] = await Promise.all([
+				api.post('/profiles/flamegraph', body, {
+					projectId: projectsState.currentProjectId ?? undefined
+				}),
+				api.post(
+					'/profiles/series',
+					{ ...body, intervalMinutes: intervalMinutes(fromIso, toIso) },
+					{ projectId: projectsState.currentProjectId ?? undefined }
+				)
+			]);
+
+			totalValue = tree?.value ?? 0;
+			flameData = tree?.children?.length ? tree : null;
+			series = points || [];
+		} catch (e: any) {
+			if (e?.status === 404) {
+				notFound = true;
+			} else {
+				console.error(e);
+				error = e.message || 'Failed to load profile';
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	const sparkPath = $derived.by(() => {
+		if (series.length < 2 || seriesPeak === 0) return '';
+		const step = 100 / (series.length - 1);
+		return series
+			.map(
+				(p, i) =>
+					`${i === 0 ? 'M' : 'L'} ${(i * step).toFixed(2)} ${(30 - (p.value / seriesPeak) * 28).toFixed(2)}`
+			)
+			.join(' ');
+	});
+
+	onMount(() => {
+		loadData(false);
+	});
+</script>
+
+<div class="space-y-4">
+	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+		<div class="flex items-center gap-3">
+			<Button variant="ghost" size="sm" onclick={() => goto(resolve('/profiles'))}>
+				<ArrowLeft class="h-4 w-4" />
+			</Button>
+			<PageHeader title={data.service} subtitle="Profiles" />
+		</div>
+
+		<div class="flex flex-col">
+			<TimeRangePicker
+				bind:fromDate
+				bind:toDate
+				bind:fromTime
+				bind:toTime
+				bind:preset={selectedPreset}
+				onApply={handleTimeRangeChange}
+			/>
+		</div>
+	</div>
+
+	<Tabs.Root value={activeType} onValueChange={handleTypeChange}>
+		<Tabs.List>
+			{#each PROFILE_TYPES as meta (meta.type)}
+				<Tabs.Trigger value={meta.type}>{meta.label}</Tabs.Trigger>
+			{/each}
+		</Tabs.List>
+	</Tabs.Root>
+
+	{#if loading}
+		<div class="flex items-center justify-center py-20">
+			<LoadingCircle size="xlg" />
+		</div>
+	{:else if notFound}
+		<ErrorDisplay
+			status={404}
+			title="Not Found"
+			description="No profiles found for this service."
+			onRetry={() => loadData()}
+		/>
+	{:else if error}
+		<ErrorDisplay status={400} title="Error" description={error} onRetry={() => loadData()} />
+	{:else}
+		<div class="grid gap-4 sm:grid-cols-3">
+			<div class="rounded-lg border p-4">
+				<div class="text-sm text-muted-foreground">
+					Total {activeMeta?.category === 'heap' ? 'Memory' : 'CPU Time'}
+				</div>
+				<div class="text-2xl font-bold tabular-nums">
+					{formatProfileValue(activeType, totalValue)}
+				</div>
+			</div>
+			<div class="rounded-lg border p-4">
+				<div class="text-sm text-muted-foreground">
+					Peak {activeMeta?.isGauge ? '(avg/bucket)' : '(sum/bucket)'}
+				</div>
+				<div class="text-2xl font-bold tabular-nums">
+					{formatProfileValue(activeType, seriesPeak)}
+				</div>
+			</div>
+			<div class="rounded-lg border p-4">
+				<div class="text-sm text-muted-foreground">Trend</div>
+				{#if sparkPath}
+					<svg viewBox="0 0 100 30" preserveAspectRatio="none" class="mt-1 h-9 w-full text-primary">
+						<path
+							d={sparkPath}
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.5"
+							vector-effect="non-scaling-stroke"
+						/>
+					</svg>
+				{:else}
+					<div class="mt-1 text-sm text-muted-foreground">Not enough data</div>
+				{/if}
+			</div>
+		</div>
+
+		<div class="rounded-lg border p-4">
+			<FlameGraph data={flameData} type={activeType} />
+		</div>
+	{/if}
+</div>

--- a/frontend/src/routes/profiles/[service]/+page.ts
+++ b/frontend/src/routes/profiles/[service]/+page.ts
@@ -1,0 +1,19 @@
+import { redirect } from '@sveltejs/kit';
+import { authState } from '$lib/state/auth.svelte';
+import type { PageLoad } from './$types';
+
+export const prerender = false;
+
+export const load: PageLoad = ({ params, url }) => {
+	if (!authState.isAuthenticated) {
+		throw redirect(302, '/login');
+	}
+
+	return {
+		service: params.service,
+		type: url.searchParams.get('type'),
+		preset: url.searchParams.get('preset') || null,
+		from: url.searchParams.get('from') || null,
+		to: url.searchParams.get('to') || null
+	};
+};

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,17 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+	plugins: [svelte({ hot: false })],
+	resolve: {
+		conditions: ['browser'],
+		alias: {
+			$lib: path.resolve('./src/lib')
+		}
+	},
+	test: {
+		environment: 'jsdom',
+		include: ['src/**/*.{test,spec}.{js,ts}']
+	}
+});


### PR DESCRIPTION
PR 4 of the continuous-profiling series (ref #113): the dashboard frontend, consuming the query API merged in PR 3 (#215) — `/profiles/grouped`, `/profiles/series`, `/profiles/flamegraph`.

## What's included
- **`/profiles`** — list grouped by service + profile type (CPU / heap alloc / heap in-use) with sorting, pagination, and sticky time-range params; mirrors the existing tasks/endpoints list pattern.
- **`/profiles/[service]`** — per-service detail with a profile-type toggle, header stats, a trend sparkline (`/series`), and the flame graph (`/flamegraph`). Keyed by service+type and derives stats from the responses, since the API has no per-profile-id detail endpoint.
- **FlameGraph component** — wraps `d3-flame-graph`, themed to Traceway's design tokens.
- **profile-format util** — profile-type metadata + value formatting (ns→µs/ms/s for CPU, bytes→KB/MB/GB for heap).
- Sidebar **Profiles** entry (hidden for frontend-only projects).

## Flame graph decision gate
The plan called for prototyping with `d3-flame-graph` and keeping it only if it themes cleanly to the design system. It does (dark + light verified end-to-end against a real ingested Go pprof), so the native-renderer follow-up (PR 4b) is **not** needed for v1.

## Tests
Adds the repo's first frontend test harness (vitest + @testing-library/svelte). `profile-format` and the flame-graph wrapper are unit-tested (15 tests). `npm run check` is clean for all new files.

## Verified with real data
Ran the backend in SQLite mode, ingested a real Go CPU+heap pprof via `/api/profiles/ingest`, and drove the live UI: list → detail → flame graph, CPU↔heap toggle, dark/light themes.

## Known limitations (deferred, consistent with existing pages)
- Detail page initializes on mount; a direct detail→detail navigation (browser back/forward / manual URL) won't refresh — same as `tasks/[task]`. No in-app trigger today.
- Concurrent `loadData` is last-write-wins (no request sequencing) — same as every existing list page.

These are pre-existing codebase patterns; a codebase-wide fix is preferable to diverging here.

## Roadmap (post-v1, tracked separately)
Label/tag slicing, diff/comparison, and trace↔profile deep-linking are out of v1 scope; the data model (labels column, OTLP `Link` fields, `<runtime>:<group>:<unit>` type naming) is already shaped for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
