### PR TITLE
fix(db): cap in-memory SQLite at a single connection

### DIFF
--- a/backend/app/db/db_sqlite.go
+++ b/backend/app/db/db_sqlite.go
@@ -99,7 +99,9 @@ func openSQLite(path string, telemetry bool) (*sql.DB, error) {
 		}
 	}
 
-	if telemetry {
+	if path == ":memory:" {
+		d.SetMaxOpenConns(1)
+	} else if telemetry {
 		// WAL allows concurrent readers; SQLite still serializes writes at the
 		// file level and busy_timeout absorbs short contention windows.
 		d.SetMaxOpenConns(4)

--- a/backend/app/db/db_sqlite_pool_test.go
+++ b/backend/app/db/db_sqlite_pool_test.go
@@ -1,0 +1,51 @@
+//go:build !pgch
+
+package db
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestOpenSQLite_MemoryTelemetryTableVisibleUnderConcurrency(t *testing.T) {
+	d, err := openSQLite(":memory:", true)
+	if err != nil {
+		t.Fatalf("openSQLite: %v", err)
+	}
+	defer d.Close()
+
+	if _, err := d.Exec("CREATE TABLE probe (id INTEGER)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	const goroutines = 32
+	const iterations = 50
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, goroutines)
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if _, err := d.ExecContext(ctx, "INSERT INTO probe (id) VALUES (1)"); err != nil {
+					errCh <- err
+					return
+				}
+				var n int
+				if err := d.QueryRowContext(ctx, "SELECT count(*) FROM probe").Scan(&n); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Fatalf("concurrent op hit a pooled connection without the table (separate in-memory DB): %v", err)
+	}
+}


### PR DESCRIPTION
## Problem
In-memory SQLite (`:memory:`) gives **each pooled connection its own independent database**. Only the connection that ran migrations has the tables. The telemetry DB is pinned to `SetMaxOpenConns(4)`, so under concurrent reads + writes the pool opens fresh, empty connections → `no such table` → `500`s on everything telemetry-backed, once load ramps up.

Surfaced while manually testing continuous profiling end-to-end: browsing the flame graph (many concurrent queries) while the SDK ingested every few seconds drove the telemetry pool past one connection, and both ingestion and the dashboard started failing with `500`. The main DB dodged this only because it was already capped at 1 connection.

## Scope
Affects the **embedded/in-memory dev mode only** (`Run(opts…)`, used by local dev + test harnesses). Production loads config from env and uses **file-backed** SQLite, where all pooled connections share one database — and ClickHouse mode is unaffected. Still a real correctness bug for the in-memory path.

## Fix
Cap any `:memory:` database at a single connection, so every statement hits the migrated database. File-backed telemetry keeps its 4-connection WAL concurrency unchanged.

## Test
Adds a regression test that drives 32 goroutines of concurrent inserts+reads against an in-memory telemetry DB. It fails on the prior code (`no such table`) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)