### PR TITLE
feat(profiles): label selector on the flame-graph page

### DIFF
--- a/frontend/src/lib/components/profiles/profile-label-selector.svelte
+++ b/frontend/src/lib/components/profiles/profile-label-selector.svelte
@@ -1,0 +1,59 @@
+<script module lang="ts">
+	export function applyLabel(
+		selected: Record<string, string>,
+		key: string,
+		value: string | undefined
+	): Record<string, string> {
+		const next = { ...selected };
+		if (value === undefined) {
+			delete next[key];
+		} else {
+			next[key] = value;
+		}
+		return next;
+	}
+
+	export function labelTriggerLabel(key: string, value: string | undefined): string {
+		return value ? `${key}: ${value}` : `All ${key}`;
+	}
+</script>
+
+<script lang="ts">
+	import * as Select from '$lib/components/ui/select';
+
+	const ALL = '__all__';
+
+	let {
+		labels,
+		selected,
+		onSelect
+	}: {
+		labels: Record<string, string[]>;
+		selected: Record<string, string>;
+		onSelect: (key: string, value: string | undefined) => void;
+	} = $props();
+
+	const keys = $derived(Object.keys(labels).sort());
+</script>
+
+{#if keys.length > 0}
+	<div class="flex flex-wrap items-center gap-2">
+		{#each keys as key (key)}
+			<Select.Root
+				type="single"
+				value={selected[key] ?? ALL}
+				onValueChange={(v) => onSelect(key, v === ALL ? undefined : v)}
+			>
+				<Select.Trigger class="h-9 w-[220px]">
+					{labelTriggerLabel(key, selected[key])}
+				</Select.Trigger>
+				<Select.Content>
+					<Select.Item value={ALL}>All {key}</Select.Item>
+					{#each labels[key] as value (value)}
+						<Select.Item {value} label={value}>{value}</Select.Item>
+					{/each}
+				</Select.Content>
+			</Select.Root>
+		{/each}
+	</div>
+{/if}

--- a/frontend/src/lib/components/profiles/profile-label-selector.test.ts
+++ b/frontend/src/lib/components/profiles/profile-label-selector.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+import ProfileLabelSelector, { applyLabel, labelTriggerLabel } from './profile-label-selector.svelte';
+
+describe('applyLabel', () => {
+	it('sets the value for a key', () => {
+		expect(applyLabel({}, 'endpoint', 'GET /a')).toEqual({ endpoint: 'GET /a' });
+	});
+
+	it('replaces an existing value and leaves other keys untouched', () => {
+		expect(applyLabel({ endpoint: 'GET /a', region: 'eu' }, 'endpoint', 'GET /b')).toEqual({
+			endpoint: 'GET /b',
+			region: 'eu'
+		});
+	});
+
+	it('removes the key when the value is undefined', () => {
+		expect(applyLabel({ endpoint: 'GET /a', region: 'eu' }, 'endpoint', undefined)).toEqual({
+			region: 'eu'
+		});
+	});
+
+	it('does not mutate the input map', () => {
+		const selected = { endpoint: 'GET /a' };
+		applyLabel(selected, 'region', 'eu');
+		expect(selected).toEqual({ endpoint: 'GET /a' });
+	});
+});
+
+describe('labelTriggerLabel', () => {
+	it('shows the key and value when a value is selected', () => {
+		expect(labelTriggerLabel('endpoint', 'GET /a')).toBe('endpoint: GET /a');
+	});
+
+	it('shows an all-values placeholder when nothing is selected', () => {
+		expect(labelTriggerLabel('endpoint', undefined)).toBe('All endpoint');
+	});
+});
+
+describe('ProfileLabelSelector component', () => {
+	function triggers(container: HTMLElement) {
+		return container.querySelectorAll('[data-slot="select-trigger"]');
+	}
+
+	it('renders nothing when there are no label keys', () => {
+		const { container } = render(ProfileLabelSelector, {
+			props: { labels: {}, selected: {}, onSelect: vi.fn() }
+		});
+		expect(triggers(container)).toHaveLength(0);
+	});
+
+	it('renders one dropdown per label key', () => {
+		const { container } = render(ProfileLabelSelector, {
+			props: {
+				labels: { endpoint: ['GET /a', 'GET /b'], region: ['eu', 'us'] },
+				selected: {},
+				onSelect: vi.fn()
+			}
+		});
+		expect(triggers(container)).toHaveLength(2);
+	});
+
+	it('shows the selected value in the trigger', () => {
+		const { getByText } = render(ProfileLabelSelector, {
+			props: {
+				labels: { endpoint: ['GET /a', 'GET /b'] },
+				selected: { endpoint: 'GET /b' },
+				onSelect: vi.fn()
+			}
+		});
+		expect(getByText('endpoint: GET /b')).toBeTruthy();
+	});
+});

--- a/frontend/src/routes/profiles/[service]/+page.svelte
+++ b/frontend/src/routes/profiles/[service]/+page.svelte
@@ -179,7 +179,7 @@
 				),
 				api.post('/profiles/labels', body, {
 					projectId: projectsState.currentProjectId ?? undefined
-				})
+				}).catch(() => ({}))
 			]);
 
 			totalValue = tree?.value ?? 0;

--- a/frontend/src/routes/profiles/[service]/+page.svelte
+++ b/frontend/src/routes/profiles/[service]/+page.svelte
@@ -12,6 +12,9 @@
 	import { projectsState } from '$lib/state/projects.svelte';
 	import PageHeader from '$lib/components/issues/page-header.svelte';
 	import FlameGraph from '$lib/components/profiles/flame-graph.svelte';
+	import ProfileLabelSelector, {
+		applyLabel
+	} from '$lib/components/profiles/profile-label-selector.svelte';
 	import { CalendarDate } from '@internationalized/date';
 	import {
 		PROFILE_TYPES,
@@ -42,6 +45,8 @@
 	let flameData = $state<FlameGraphNode | null>(null);
 	let series = $state<SeriesPoint[]>([]);
 	let totalValue = $state(0);
+	let availableLabels = $state<Record<string, string[]>>({});
+	let selectedLabels = $state<Record<string, string>>({});
 	let loading = $state(true);
 	let error = $state('');
 	let notFound = $state(false);
@@ -127,6 +132,12 @@
 
 	function handleTypeChange(type: string) {
 		activeType = type;
+		selectedLabels = {};
+		loadData(true);
+	}
+
+	function handleLabelSelect(key: string, value: string | undefined) {
+		selectedLabels = applyLabel(selectedLabels, key, value);
 		loadData(true);
 	}
 
@@ -155,20 +166,26 @@
 		};
 
 		try {
-			const [tree, points] = await Promise.all([
-				api.post('/profiles/flamegraph', body, {
-					projectId: projectsState.currentProjectId ?? undefined
-				}),
+			const [tree, points, labels] = await Promise.all([
+				api.post(
+					'/profiles/flamegraph',
+					{ ...body, labels: selectedLabels },
+					{ projectId: projectsState.currentProjectId ?? undefined }
+				),
 				api.post(
 					'/profiles/series',
 					{ ...body, intervalMinutes: intervalMinutes(fromIso, toIso) },
 					{ projectId: projectsState.currentProjectId ?? undefined }
-				)
+				),
+				api.post('/profiles/labels', body, {
+					projectId: projectsState.currentProjectId ?? undefined
+				})
 			]);
 
 			totalValue = tree?.value ?? 0;
 			flameData = tree?.children?.length ? tree : null;
 			series = points || [];
+			availableLabels = labels || {};
 		} catch (e: any) {
 			if (e?.status === 404) {
 				notFound = true;
@@ -225,6 +242,12 @@
 			{/each}
 		</Tabs.List>
 	</Tabs.Root>
+
+	<ProfileLabelSelector
+		labels={availableLabels}
+		selected={selectedLabels}
+		onSelect={handleLabelSelect}
+	/>
 
 	{#if loading}
 		<div class="flex items-center justify-center py-20">


### PR DESCRIPTION
> **Depends on #238** — the backend `POST /profiles/labels` endpoint lands there. Until that merges, this UI degrades gracefully (the dropdown simply doesn't render).

## What

Adds a per-key **label selector** to the profiles flame-graph page (`/profiles/[service]`).

- On load, fetches available labels from `POST /profiles/labels` (response shape `{ "endpoint": ["GET /a", …] }`) alongside the existing flamegraph/series requests.
- Renders one dropdown per label key via a new `ProfileLabelSelector` component, placed between the profile-type tabs and the graph so it stays visible during re-query.
- Choosing a value passes `labels: { endpoint: value }` into the existing `POST /profiles/flamegraph` request and re-queries; choosing **All** clears that key.

Frontend only (`src/routes/profiles/**`, `src/lib/components/profiles/**`).

## Why

Profiling data carries labels (currently `endpoint`), but there was no way to scope a flame graph to one of them. This lets users narrow a service's profile to a single endpoint.

## Design notes

- **Reset on type switch:** label sets differ per profile type (CPU vs heap), so `selectedLabels` is cleared when the type tab changes — a stale value would yield an empty graph.
- **In-memory only:** filters are not persisted to the URL (matches the existing `tag-filter` pattern); kept minimal.
- **Graceful degradation:** the `/profiles/labels` fetch is `.catch`-guarded so a label-discovery failure only suppresses the dropdown rather than blanking the flame graph (follow-up commit).

## Tests

New `profile-label-selector.test.ts` (9 tests): the pure helpers (`applyLabel` immutability/add/remove, `labelTriggerLabel`) plus render behavior (nothing when empty, one dropdown per key, selected value in trigger). Full frontend suite green; `svelte-check` adds no new errors.

Verified manually end-to-end against the PR-238 backend: dropdown populates with `/a` and `/b`, and selecting one rescopes the graph (300 ns → 200 ns / 100 ns).

## Reviewer notes — considered, intentionally not changed

- **Filter persists across time-range change** (not reset like type change). Defensible — you usually want to keep an endpoint filter while zooming time — but flagged for your call.
- **No request-sequencing guard** on rapid successive selections (pre-existing on this page for flamegraph/series; out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
