### PR TITLE
feat(profiling): flame-graph diff endpoint

### DIFF
--- a/backend/app/controllers/profile.controller.go
+++ b/backend/app/controllers/profile.controller.go
@@ -38,6 +38,19 @@ type ProfileFlameGraphRequest struct {
 	Labels      map[string]string `json:"labels"`
 }
 
+type ProfileFlameGraphDiffSide struct {
+	FromDate time.Time         `json:"fromDate"`
+	ToDate   time.Time         `json:"toDate"`
+	Labels   map[string]string `json:"labels"`
+}
+
+type ProfileFlameGraphDiffRequest struct {
+	ServiceName string                    `json:"serviceName"`
+	Type        string                    `json:"type"`
+	Left        ProfileFlameGraphDiffSide `json:"left"`
+	Right       ProfileFlameGraphDiffSide `json:"right"`
+}
+
 type ProfileLabelsRequest struct {
 	FromDate    time.Time `json:"fromDate"`
 	ToDate      time.Time `json:"toDate"`
@@ -160,6 +173,37 @@ func (p profileController) DiscoverLabels(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, labels)
+}
+
+func (p profileController) GetFlameGraphDiff(c *gin.Context) {
+	projectId, err := middleware.GetProjectId(c)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("RequireProjectAccess middleware must be applied: %w", err))
+		return
+	}
+
+	var request ProfileFlameGraphDiffRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if request.ServiceName == "" || request.Type == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "serviceName and type are required"})
+		return
+	}
+
+	leftRows, err := repositories.ProfileRepository.GetFlameGraph(c, projectId, request.ServiceName, request.Type, request.Left.FromDate, request.Left.ToDate, request.Left.Labels)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("error loading baseline flame graph: %w", err))
+		return
+	}
+	rightRows, err := repositories.ProfileRepository.GetFlameGraph(c, projectId, request.ServiceName, request.Type, request.Right.FromDate, request.Right.ToDate, request.Right.Labels)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("error loading comparison flame graph: %w", err))
+		return
+	}
+
+	c.JSON(http.StatusOK, services.FoldDiff(leftRows, rightRows))
 }
 
 var ProfileController = profileController{}

--- a/backend/app/controllers/routes.go
+++ b/backend/app/controllers/routes.go
@@ -99,6 +99,7 @@ func RegisterControllers(router *gin.RouterGroup) {
 	router.POST("/profiles/grouped", middleware.UseAppAuth, middleware.RequireProjectAccess, ProfileController.FindGroupedByService)
 	router.POST("/profiles/series", middleware.UseAppAuth, middleware.RequireProjectAccess, ProfileController.GetSeries)
 	router.POST("/profiles/flamegraph", middleware.UseAppAuth, middleware.RequireProjectAccess, ProfileController.GetFlameGraph)
+	router.POST("/profiles/flamegraph/diff", middleware.UseAppAuth, middleware.RequireProjectAccess, ProfileController.GetFlameGraphDiff)
 	router.POST("/profiles/labels", middleware.UseAppAuth, middleware.RequireProjectAccess, ProfileController.DiscoverLabels)
 
 	router.POST("/ai-traces/grouped", middleware.UseAppAuth, middleware.RequireProjectAccess, AiTraceController.FindGroupedByTraceName)

--- a/backend/app/services/profile_flamegraph_diff.go
+++ b/backend/app/services/profile_flamegraph_diff.go
@@ -1,0 +1,60 @@
+package services
+
+import (
+	"sort"
+
+	"github.com/tracewayapp/traceway/backend/app/models"
+)
+
+type DiffNode struct {
+	Name     string      `json:"name"`
+	Left     int64       `json:"left"`
+	Right    int64       `json:"right"`
+	Children []*DiffNode `json:"children,omitempty"`
+}
+
+func FoldDiff(left, right []models.ProfileStackValue) *DiffNode {
+	root := &DiffNode{Name: "root"}
+	childIndex := map[*DiffNode]map[string]*DiffNode{}
+
+	addSide := func(stacks []models.ProfileStackValue, add func(*DiffNode, int64)) {
+		for _, s := range stacks {
+			add(root, s.Value)
+			node := root
+			for _, frame := range s.Stack {
+				children, ok := childIndex[node]
+				if !ok {
+					children = map[string]*DiffNode{}
+					childIndex[node] = children
+				}
+				child, ok := children[frame]
+				if !ok {
+					child = &DiffNode{Name: frame}
+					children[frame] = child
+					node.Children = append(node.Children, child)
+				}
+				add(child, s.Value)
+				node = child
+			}
+		}
+	}
+
+	addSide(left, func(n *DiffNode, v int64) { n.Left += v })
+	addSide(right, func(n *DiffNode, v int64) { n.Right += v })
+
+	sortDiffChildren(root)
+	return root
+}
+
+func sortDiffChildren(n *DiffNode) {
+	sort.SliceStable(n.Children, func(i, j int) bool {
+		a, b := n.Children[i], n.Children[j]
+		if a.Left+a.Right != b.Left+b.Right {
+			return a.Left+a.Right > b.Left+b.Right
+		}
+		return a.Name < b.Name
+	})
+	for _, c := range n.Children {
+		sortDiffChildren(c)
+	}
+}

--- a/backend/app/services/profile_flamegraph_diff_test.go
+++ b/backend/app/services/profile_flamegraph_diff_test.go
@@ -1,0 +1,100 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/tracewayapp/traceway/backend/app/models"
+)
+
+func diffChild(n *DiffNode, name string) *DiffNode {
+	for _, c := range n.Children {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func sv(value int64, frames ...string) models.ProfileStackValue {
+	return models.ProfileStackValue{Stack: frames, Value: value}
+}
+
+func TestFoldDiff_SharedStackMergesBothSides(t *testing.T) {
+	left := []models.ProfileStackValue{sv(100, "main", "work")}
+	right := []models.ProfileStackValue{sv(150, "main", "work")}
+
+	root := FoldDiff(left, right)
+	if root.Left != 100 || root.Right != 150 {
+		t.Fatalf("root = (L%d,R%d), want (100,150)", root.Left, root.Right)
+	}
+	main := diffChild(root, "main")
+	if main == nil || main.Left != 100 || main.Right != 150 {
+		t.Fatalf("main = %+v, want (100,150)", main)
+	}
+	work := diffChild(main, "work")
+	if work == nil || work.Left != 100 || work.Right != 150 {
+		t.Fatalf("work = %+v, want (100,150)", work)
+	}
+}
+
+func TestFoldDiff_OneSidedStacksZeroOnTheOther(t *testing.T) {
+	left := []models.ProfileStackValue{sv(50, "main", "onlyLeft")}
+	right := []models.ProfileStackValue{sv(70, "main", "onlyRight")}
+
+	root := FoldDiff(left, right)
+	if root.Left != 50 || root.Right != 70 {
+		t.Fatalf("root = (L%d,R%d), want (50,70)", root.Left, root.Right)
+	}
+	onlyLeft := diffChild(diffChild(root, "main"), "onlyLeft")
+	if onlyLeft == nil || onlyLeft.Left != 50 || onlyLeft.Right != 0 {
+		t.Errorf("onlyLeft = %+v, want (50,0)", onlyLeft)
+	}
+	onlyRight := diffChild(diffChild(root, "main"), "onlyRight")
+	if onlyRight == nil || onlyRight.Left != 0 || onlyRight.Right != 70 {
+		t.Errorf("onlyRight = %+v, want (0,70)", onlyRight)
+	}
+}
+
+func TestFoldDiff_CombinedAccumulatesCumulatively(t *testing.T) {
+	left := []models.ProfileStackValue{sv(100, "main", "b"), sv(50, "main", "c")}
+	right := []models.ProfileStackValue{sv(150, "main", "b"), sv(70, "main", "d")}
+
+	root := FoldDiff(left, right)
+	if root.Left != 150 || root.Right != 220 {
+		t.Fatalf("root = (L%d,R%d), want (150,220)", root.Left, root.Right)
+	}
+	main := diffChild(root, "main")
+	if main.Left != 150 || main.Right != 220 {
+		t.Fatalf("main cumulative = (L%d,R%d), want (150,220)", main.Left, main.Right)
+	}
+	if b := diffChild(main, "b"); b == nil || b.Left != 100 || b.Right != 150 {
+		t.Errorf("b = %+v, want (100,150)", b)
+	}
+	if cc := diffChild(main, "c"); cc == nil || cc.Left != 50 || cc.Right != 0 {
+		t.Errorf("c = %+v, want (50,0)", cc)
+	}
+	if d := diffChild(main, "d"); d == nil || d.Left != 0 || d.Right != 70 {
+		t.Errorf("d = %+v, want (0,70)", d)
+	}
+}
+
+func TestFoldDiff_Empty(t *testing.T) {
+	root := FoldDiff(nil, nil)
+	if root == nil || root.Left != 0 || root.Right != 0 || len(root.Children) != 0 {
+		t.Fatalf("empty diff = %+v, want zero root with no children", root)
+	}
+}
+
+func TestFoldDiff_ChildrenSortedByCombinedMagnitude(t *testing.T) {
+	left := []models.ProfileStackValue{sv(10, "main", "small"), sv(100, "main", "big")}
+	right := []models.ProfileStackValue{sv(10, "main", "small"), sv(100, "main", "big")}
+
+	root := FoldDiff(left, right)
+	main := diffChild(root, "main")
+	if main == nil {
+		t.Fatal("main node missing")
+	}
+	if len(main.Children) != 2 || main.Children[0].Name != "big" {
+		t.Errorf("children order = %v, want big first (sorted by left+right desc)", main.Children)
+	}
+}


### PR DESCRIPTION
Backend half of the **diff / comparison flame graph** (post-v1 roadmap, "better Pyroscope" parity). Lets you compare two flame graphs and see which functions got heavier or lighter — e.g. *did this deploy make `/checkout` slower?*

## What
- `POST /profiles/flamegraph/diff` — takes a shared `serviceName`+`type` and two sides, each with its own `fromDate`/`toDate`/`labels`:
  ```json
  { "serviceName": "...", "type": "go:profile_cpu:nanoseconds",
    "left":  {"fromDate","toDate","labels"},
    "right": {"fromDate","toDate","labels"} }
  ```
  Per-side window + labels means **one endpoint covers both modes**: time-range diff (different windows) and label diff (e.g. `endpoint=/checkout` vs `/cart`).
- `services.FoldDiff` merges the two collapsed-stack result sets into a single tree where every node carries both sides' cumulative values (`{name, left, right, children}`); shared stacks combine, one-sided stacks read zero on the other.
- Reuses the existing `GetFlameGraph` query once per side — no new query path.

## Why this shape
The backend returns **absolute** `left`/`right` per node plus root totals and leaves **normalization to the frontend**, so comparing windows of different durations (5 min vs 1 hour) stays fair and the FE can offer absolute *or* normalized differential views.

## Tests
`FoldDiff` is covered by table tests: shared-stack merge, one-sided→zero, cumulative nested accumulation, empty input, and child ordering. Builds on both `pgch` and default (SQLite) tags; `go vet` clean. (The only failing suite tests are the pre-existing Android/R8 symbolication + OTel-snapshot tests that require native tooling absent in this environment.)

Frontend compare mode (differential rendering) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)