### PR TITLE
feat(profiles): differential flame graph + compare mode (frontend)

### DIFF
--- a/frontend/src/lib/components/profiles/flame-graph.svelte
+++ b/frontend/src/lib/components/profiles/flame-graph.svelte
@@ -11,18 +11,29 @@
 		const pctStr = Number(pct.toFixed(1)).toString();
 		return `${name} — ${formatProfileValue(type, value)} (${pctStr}%)`;
 	}
+
+	export function flameDiffTooltipLabel(
+		name: string,
+		left: number,
+		right: number,
+		type: string
+	): string {
+		return `${name} — ${formatProfileValue(type, left)} → ${formatProfileValue(type, right)}`;
+	}
 </script>
 
 <script lang="ts">
 	import flamegraph, { type FlameGraphNode } from 'd3-flame-graph';
 	import { select } from 'd3-selection';
+	import { diffColor, type FlameDiffNode } from '$lib/utils/profile-diff';
 
 	interface Props {
-		data: FlameGraphNode | null;
+		data: FlameGraphNode | FlameDiffNode | null;
 		type: string;
+		differential?: boolean;
 	}
 
-	let { data, type }: Props = $props();
+	let { data, type, differential = false }: Props = $props();
 
 	let container = $state<HTMLDivElement>();
 	let width = $state(0);
@@ -49,8 +60,19 @@
 			.minFrameSize(1)
 			.transitionDuration(200)
 			.sort(true)
-			.selfValue(false)
-			.label((d) => flameTooltipLabel(d.data.name, d.data.value, total, currentType));
+			.selfValue(false);
+
+		if (differential) {
+			const diffOf = (d: unknown) => (d as { data: FlameDiffNode }).data;
+			chart
+				.setColorMapper((d) => diffColor(diffOf(d).delta))
+				.label((d) => {
+					const n = diffOf(d);
+					return flameDiffTooltipLabel(n.name, n.left, n.right, currentType);
+				});
+		} else {
+			chart.label((d) => flameTooltipLabel(d.data.name, d.data.value, total, currentType));
+		}
 
 		select(el).datum(data).call(chart);
 

--- a/frontend/src/lib/components/profiles/flame-graph.test.ts
+++ b/frontend/src/lib/components/profiles/flame-graph.test.ts
@@ -20,7 +20,7 @@ vi.mock('d3-selection', () => {
 	return { select: () => sel };
 });
 
-import FlameGraph, { flameTooltipLabel } from './flame-graph.svelte';
+import FlameGraph, { flameTooltipLabel, flameDiffTooltipLabel } from './flame-graph.svelte';
 import { CPU_NANOS } from '$lib/utils/profile-format';
 
 const tree = {
@@ -39,6 +39,14 @@ describe('flameTooltipLabel', () => {
 
 	it('renders 0% instead of NaN when the total is zero', () => {
 		expect(flameTooltipLabel('main.work', 10, 0, CPU_NANOS)).toBe('main.work — 10 ns (0%)');
+	});
+});
+
+describe('flameDiffTooltipLabel', () => {
+	it('formats baseline → comparison values', () => {
+		expect(flameDiffTooltipLabel('main.work', 1_000_000, 1_500_000, CPU_NANOS)).toBe(
+			'main.work — 1 ms → 1.5 ms'
+		);
 	});
 });
 
@@ -66,5 +74,12 @@ describe('FlameGraph component', () => {
 		const next = { name: 'root', value: 50, self: 0, children: [] };
 		await rerender({ data: next, type: CPU_NANOS });
 		expect(datumSpy).toHaveBeenCalledWith(next);
+	});
+
+	it('renders a differential flame graph with the diff tree', () => {
+		const diffTree = { name: 'root', value: 250, left: 100, right: 150, delta: 0, children: [] };
+		render(FlameGraph, { props: { data: diffTree, type: CPU_NANOS, differential: true } });
+		expect(flamegraphSpy).toHaveBeenCalled();
+		expect(datumSpy).toHaveBeenCalledWith(diffTree);
 	});
 });

--- a/frontend/src/lib/utils/profile-diff.test.ts
+++ b/frontend/src/lib/utils/profile-diff.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { diffToFlameNode, diffColor, type DiffNode } from './profile-diff';
+
+function channels(color: string): [number, number, number] {
+	const m = color.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+	if (!m) throw new Error(`not an rgb() color: ${color}`);
+	return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+describe('diffToFlameNode', () => {
+	it('uses value = left + right (union layout)', () => {
+		const root: DiffNode = {
+			name: 'root',
+			left: 100,
+			right: 150,
+			children: [{ name: 'main', left: 100, right: 150, children: [] }]
+		};
+		const fn = diffToFlameNode(root);
+		expect(fn.value).toBe(250);
+		expect(fn.children[0].value).toBe(250);
+		expect(fn.children[0].left).toBe(100);
+		expect(fn.children[0].right).toBe(150);
+	});
+
+	it('computes normalized delta = right/rootRight - left/rootLeft', () => {
+		const root: DiffNode = {
+			name: 'root',
+			left: 200,
+			right: 200,
+			children: [{ name: 'a', left: 100, right: 150, children: [] }]
+		};
+		const fn = diffToFlameNode(root);
+		expect(fn.children[0].delta).toBeCloseTo(0.25, 5);
+	});
+
+	it('keeps delta finite when one side has no data', () => {
+		const root: DiffNode = {
+			name: 'root',
+			left: 0,
+			right: 100,
+			children: [{ name: 'a', left: 0, right: 100, children: [] }]
+		};
+		const fn = diffToFlameNode(root);
+		expect(Number.isFinite(fn.children[0].delta)).toBe(true);
+		expect(fn.children[0].delta).toBeCloseTo(1, 5);
+	});
+
+	it('handles an empty root', () => {
+		const fn = diffToFlameNode({ name: 'root', left: 0, right: 0 });
+		expect(fn.value).toBe(0);
+		expect(fn.delta).toBe(0);
+		expect(fn.children).toEqual([]);
+	});
+});
+
+describe('diffColor', () => {
+	it('is red-dominant when the comparison side is heavier (delta > 0)', () => {
+		const [r, g] = channels(diffColor(0.5));
+		expect(r).toBeGreaterThan(g);
+	});
+
+	it('is green-dominant when the comparison side is lighter (delta < 0)', () => {
+		const [r, g] = channels(diffColor(-0.5));
+		expect(g).toBeGreaterThan(r);
+	});
+
+	it('is roughly neutral at delta 0', () => {
+		const [r, g] = channels(diffColor(0));
+		expect(Math.abs(r - g)).toBeLessThan(10);
+	});
+});

--- a/frontend/src/lib/utils/profile-diff.ts
+++ b/frontend/src/lib/utils/profile-diff.ts
@@ -1,0 +1,42 @@
+export interface DiffNode {
+	name: string;
+	left: number;
+	right: number;
+	children?: DiffNode[];
+}
+
+export interface FlameDiffNode {
+	name: string;
+	value: number;
+	left: number;
+	right: number;
+	delta: number;
+	children: FlameDiffNode[];
+}
+
+export function diffToFlameNode(root: DiffNode): FlameDiffNode {
+	return buildDiffNode(root, root.left, root.right);
+}
+
+function buildDiffNode(node: DiffNode, rootLeft: number, rootRight: number): FlameDiffNode {
+	const leftProp = rootLeft > 0 ? node.left / rootLeft : 0;
+	const rightProp = rootRight > 0 ? node.right / rootRight : 0;
+	return {
+		name: node.name,
+		value: node.left + node.right,
+		left: node.left,
+		right: node.right,
+		delta: rightProp - leftProp,
+		children: (node.children ?? []).map((c) => buildDiffNode(c, rootLeft, rootRight))
+	};
+}
+
+export function diffColor(delta: number): string {
+	const mag = Math.min(1, Math.abs(delta));
+	const strong = Math.round(128 + 127 * mag);
+	const weak = Math.round(128 - 100 * mag);
+	if (delta >= 0) {
+		return `rgb(${strong}, ${weak}, ${weak})`;
+	}
+	return `rgb(${weak}, ${strong}, ${weak})`;
+}

--- a/frontend/src/routes/profiles/[service]/+page.svelte
+++ b/frontend/src/routes/profiles/[service]/+page.svelte
@@ -12,6 +12,7 @@
 	import { projectsState } from '$lib/state/projects.svelte';
 	import PageHeader from '$lib/components/issues/page-header.svelte';
 	import FlameGraph from '$lib/components/profiles/flame-graph.svelte';
+	import { diffToFlameNode, type DiffNode, type FlameDiffNode } from '$lib/utils/profile-diff';
 	import ProfileLabelSelector, {
 		applyLabel
 	} from '$lib/components/profiles/profile-label-selector.svelte';
@@ -43,10 +44,14 @@
 	let { data } = $props();
 
 	let flameData = $state<FlameGraphNode | null>(null);
+	let diffData = $state<FlameDiffNode | null>(null);
+	let compareMode = $state(false);
 	let series = $state<SeriesPoint[]>([]);
 	let totalValue = $state(0);
 	let availableLabels = $state<Record<string, string[]>>({});
 	let selectedLabels = $state<Record<string, string>>({});
+	let baseAvailableLabels = $state<Record<string, string[]>>({});
+	let baseSelectedLabels = $state<Record<string, string>>({});
 	let loading = $state(true);
 	let error = $state('');
 	let notFound = $state(false);
@@ -80,6 +85,13 @@
 	let fromTime = $state(dateToTimeString(initialRange.from, timezone));
 	let toTime = $state(dateToTimeString(initialRange.to, timezone));
 
+	const baseInit = getTimeRangeFromPreset('24h', timezone);
+	let basePreset = $state<string | null>('24h');
+	let baseFromDate = $state<CalendarDate>(dateToCalendarDate(baseInit.from, timezone));
+	let baseToDate = $state<CalendarDate>(dateToCalendarDate(baseInit.to, timezone));
+	let baseFromTime = $state(dateToTimeString(baseInit.from, timezone));
+	let baseToTime = $state(dateToTimeString(baseInit.to, timezone));
+
 	const activeMeta = $derived<ProfileTypeMeta | undefined>(getProfileTypeMeta(activeType));
 	const seriesPeak = $derived(series.reduce((max, p) => Math.max(max, p.value), 0));
 
@@ -109,6 +121,42 @@
 		return toUTCISO(dt);
 	}
 
+	function baseFromDateTimeUTC(): string {
+		const [hour, minute] = (baseFromTime || '00:00').split(':').map(Number);
+		const dt = calendarDateTimeToLuxon(
+			{ year: baseFromDate.year, month: baseFromDate.month, day: baseFromDate.day, hour, minute },
+			timezone
+		);
+		return toUTCISO(dt);
+	}
+
+	function baseToDateTimeUTC(): string {
+		const [hour, minute] = (baseToTime || '23:59').split(':').map(Number);
+		const dt = calendarDateTimeToLuxon(
+			{ year: baseToDate.year, month: baseToDate.month, day: baseToDate.day, hour, minute },
+			timezone
+		).endOf('minute');
+		return toUTCISO(dt);
+	}
+
+	function toggleCompare() {
+		compareMode = !compareMode;
+		loadData(true);
+	}
+
+	function handleBaseRangeChange(
+		from: { date: CalendarDate; time: string },
+		to: { date: CalendarDate; time: string },
+		preset: string | null
+	) {
+		baseFromDate = from.date;
+		baseFromTime = from.time;
+		baseToDate = to.date;
+		baseToTime = to.time;
+		basePreset = preset;
+		loadData(true);
+	}
+
 	function intervalMinutes(fromIso: string, toIso: string): number {
 		const spanMinutes = Math.max(
 			1,
@@ -133,11 +181,17 @@
 	function handleTypeChange(type: string) {
 		activeType = type;
 		selectedLabels = {};
+		baseSelectedLabels = {};
 		loadData(true);
 	}
 
 	function handleLabelSelect(key: string, value: string | undefined) {
 		selectedLabels = applyLabel(selectedLabels, key, value);
+		loadData(true);
+	}
+
+	function handleBaseLabelSelect(key: string, value: string | undefined) {
+		baseSelectedLabels = applyLabel(baseSelectedLabels, key, value);
 		loadData(true);
 	}
 
@@ -166,26 +220,56 @@
 		};
 
 		try {
-			const [tree, points, labels] = await Promise.all([
-				api.post(
-					'/profiles/flamegraph',
-					{ ...body, labels: selectedLabels },
-					{ projectId: projectsState.currentProjectId ?? undefined }
-				),
+			const projectId = projectsState.currentProjectId ?? undefined;
+			const discoverLabels = (from: string, to: string) =>
+				api
+					.post(
+						'/profiles/labels',
+						{ fromDate: from, toDate: to, serviceName: data.service, type: activeType },
+						{ projectId }
+					)
+					.catch(() => ({}));
+			const flamePromise = compareMode
+				? api.post(
+						'/profiles/flamegraph/diff',
+						{
+							serviceName: data.service,
+							type: activeType,
+							left: {
+								fromDate: baseFromDateTimeUTC(),
+								toDate: baseToDateTimeUTC(),
+								labels: baseSelectedLabels
+							},
+							right: { fromDate: fromIso, toDate: toIso, labels: selectedLabels }
+						},
+						{ projectId }
+					)
+				: api.post('/profiles/flamegraph', { ...body, labels: selectedLabels }, { projectId });
+
+			const [tree, points, labels, baseLabels] = await Promise.all([
+				flamePromise,
 				api.post(
 					'/profiles/series',
 					{ ...body, intervalMinutes: intervalMinutes(fromIso, toIso) },
-					{ projectId: projectsState.currentProjectId ?? undefined }
+					{ projectId }
 				),
-				api.post('/profiles/labels', body, {
-					projectId: projectsState.currentProjectId ?? undefined
-				}).catch(() => ({}))
+				discoverLabels(fromIso, toIso),
+				compareMode ? discoverLabels(baseFromDateTimeUTC(), baseToDateTimeUTC()) : Promise.resolve({})
 			]);
 
-			totalValue = tree?.value ?? 0;
-			flameData = tree?.children?.length ? tree : null;
+			if (compareMode) {
+				const root = diffToFlameNode(tree as DiffNode);
+				diffData = root.children.length ? root : null;
+				flameData = null;
+				totalValue = (tree as DiffNode)?.right ?? 0;
+			} else {
+				flameData = tree?.children?.length ? tree : null;
+				diffData = null;
+				totalValue = tree?.value ?? 0;
+			}
 			series = points || [];
 			availableLabels = labels || {};
+			baseAvailableLabels = baseLabels || {};
 		} catch (e: any) {
 			if (e?.status === 404) {
 				notFound = true;
@@ -223,15 +307,33 @@
 			<PageHeader title={data.service} subtitle="Profiles" />
 		</div>
 
-		<div class="flex flex-col">
-			<TimeRangePicker
-				bind:fromDate
-				bind:toDate
-				bind:fromTime
-				bind:toTime
-				bind:preset={selectedPreset}
-				onApply={handleTimeRangeChange}
-			/>
+		<div class="flex flex-col items-end gap-2">
+			<div class="flex items-center gap-2">
+				<Button variant={compareMode ? 'default' : 'outline'} size="sm" onclick={toggleCompare}>
+					Compare
+				</Button>
+				<TimeRangePicker
+					bind:fromDate
+					bind:toDate
+					bind:fromTime
+					bind:toTime
+					bind:preset={selectedPreset}
+					onApply={handleTimeRangeChange}
+				/>
+			</div>
+			{#if compareMode}
+				<div class="flex items-center gap-2">
+					<span class="text-xs whitespace-nowrap text-muted-foreground">Baseline</span>
+					<TimeRangePicker
+						bind:fromDate={baseFromDate}
+						bind:toDate={baseToDate}
+						bind:fromTime={baseFromTime}
+						bind:toTime={baseToTime}
+						bind:preset={basePreset}
+						onApply={handleBaseRangeChange}
+					/>
+				</div>
+			{/if}
 		</div>
 	</div>
 
@@ -243,11 +345,32 @@
 		</Tabs.List>
 	</Tabs.Root>
 
-	<ProfileLabelSelector
-		labels={availableLabels}
-		selected={selectedLabels}
-		onSelect={handleLabelSelect}
-	/>
+	{#if compareMode}
+		<div class="space-y-2">
+			<div class="flex items-center gap-2">
+				<span class="w-16 shrink-0 text-xs text-muted-foreground">Current</span>
+				<ProfileLabelSelector
+					labels={availableLabels}
+					selected={selectedLabels}
+					onSelect={handleLabelSelect}
+				/>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="w-16 shrink-0 text-xs text-muted-foreground">Baseline</span>
+				<ProfileLabelSelector
+					labels={baseAvailableLabels}
+					selected={baseSelectedLabels}
+					onSelect={handleBaseLabelSelect}
+				/>
+			</div>
+		</div>
+	{:else}
+		<ProfileLabelSelector
+			labels={availableLabels}
+			selected={selectedLabels}
+			onSelect={handleLabelSelect}
+		/>
+	{/if}
 
 	{#if loading}
 		<div class="flex items-center justify-center py-20">
@@ -299,7 +422,22 @@
 		</div>
 
 		<div class="rounded-lg border p-4">
-			<FlameGraph data={flameData} type={activeType} />
+			{#if compareMode}
+				<div class="mb-3 flex items-center gap-4 text-xs text-muted-foreground">
+					<span class="flex items-center gap-1">
+						<span class="inline-block h-2.5 w-2.5 rounded-sm" style="background: rgb(191, 78, 78)"
+						></span> heavier now
+					</span>
+					<span class="flex items-center gap-1">
+						<span class="inline-block h-2.5 w-2.5 rounded-sm" style="background: rgb(78, 191, 78)"
+						></span> lighter now
+					</span>
+					<span>(baseline → current)</span>
+				</div>
+				<FlameGraph data={diffData} type={activeType} differential />
+			{:else}
+				<FlameGraph data={flameData} type={activeType} />
+			{/if}
 		</div>
 	{/if}
 </div>

--- a/frontend/src/routes/profiles/[service]/+page.svelte
+++ b/frontend/src/routes/profiles/[service]/+page.svelte
@@ -95,6 +95,9 @@
 	const activeMeta = $derived<ProfileTypeMeta | undefined>(getProfileTypeMeta(activeType));
 	const seriesPeak = $derived(series.reduce((max, p) => Math.max(max, p.value), 0));
 
+	const hasCurrentLabels = $derived(Object.keys(availableLabels).length > 0);
+	const hasBaselineLabels = $derived(Object.keys(baseAvailableLabels).length > 0);
+
 	function updateUrlParams(pushToHistory = true) {
 		const params: Record<string, string | undefined> = selectedPreset
 			? { preset: selectedPreset }
@@ -346,24 +349,30 @@
 	</Tabs.Root>
 
 	{#if compareMode}
-		<div class="space-y-2">
-			<div class="flex items-center gap-2">
-				<span class="w-16 shrink-0 text-xs text-muted-foreground">Current</span>
-				<ProfileLabelSelector
-					labels={availableLabels}
-					selected={selectedLabels}
-					onSelect={handleLabelSelect}
-				/>
+		{#if hasCurrentLabels || hasBaselineLabels}
+			<div class="space-y-2">
+				{#if hasCurrentLabels}
+					<div class="flex items-center gap-2">
+						<span class="w-16 shrink-0 text-xs text-muted-foreground">Current</span>
+						<ProfileLabelSelector
+							labels={availableLabels}
+							selected={selectedLabels}
+							onSelect={handleLabelSelect}
+						/>
+					</div>
+				{/if}
+				{#if hasBaselineLabels}
+					<div class="flex items-center gap-2">
+						<span class="w-16 shrink-0 text-xs text-muted-foreground">Baseline</span>
+						<ProfileLabelSelector
+							labels={baseAvailableLabels}
+							selected={baseSelectedLabels}
+							onSelect={handleBaseLabelSelect}
+						/>
+					</div>
+				{/if}
 			</div>
-			<div class="flex items-center gap-2">
-				<span class="w-16 shrink-0 text-xs text-muted-foreground">Baseline</span>
-				<ProfileLabelSelector
-					labels={baseAvailableLabels}
-					selected={baseSelectedLabels}
-					onSelect={handleBaseLabelSelect}
-				/>
-			</div>
-		</div>
+		{/if}
 	{:else}
 		<ProfileLabelSelector
 			labels={availableLabels}


### PR DESCRIPTION
## What

Adds a **Compare** mode to the profile detail page (`/profiles/[service]`) that renders a **differential flame graph** against the `POST /profiles/flamegraph/diff` endpoint.

- **`profile-diff.ts`** — `diffToFlameNode` merges the backend diff tree into a d3 flame node: frame width = `left + right` (union layout, so frames present on either side both show), and a **normalized delta** = `right/rootRight − left/rootLeft`. `diffColor` maps that delta to **red** (heavier now) / **green** (lighter now).
- **`flame-graph.svelte`** — optional `differential` mode wiring `diffColor` as the d3 colour mapper plus a `baseline → current` tooltip.
- **`/profiles/[service]` page** — a **Compare** toggle reveals a **baseline time-range picker** and **per-side label selectors** (Current vs Baseline). You can diff two **time windows** (all profile types) and/or two **label sets** on CPU (e.g. `endpoint=/checkout` vs `/cart`).

## Why

Comparison/diff is table-stakes for a profiler — *"what got slower / allocated more between these two windows (or endpoints)?"*. This completes the per-side diff UX on top of the backend endpoint in #240.

## Notes

- **Depends on #240** (`feat(profiling): flame-graph diff endpoint`) — that backend PR must merge first for this UI to function against `main`.
- The `/profiles` **nav link is currently disabled on `main`** (`d35d8016`, "disabled until fully done"); reach the view directly at `/profiles` → pick a service → **Compare**.
- **Heap vs CPU labels:** Go's runtime attaches `pprof.Do` labels only to **CPU** samples, not heap allocations, so heap profiles carry no labels. In compare mode the per-side label selectors are gated on label presence, so heap comparison cleanly shows just the time-range axis (no orphan "Current/Baseline" rows). Heap In-Use diffs as a **gauge** (latest snapshot per side) and Heap Allocations as a **counter** (summed) — both handled by the backend's existing `IsGauge` branch.

## Testing

- `profile-diff.ts` unit tests: union value, normalized delta, one-sided/empty, red/green/neutral colour.
- `flame-graph.svelte`: differential render + `baseline → current` tooltip.
- Full profiling FE suite green (33 tests); `npm run check` clean for profiling files.
- Manually verified end to end against a real gin app with `pprof.Do` endpoint labels: per-side **label** diff (`/cart` ≈ 1.0s vs `/checkout` ≈ 8.3s) and per-side **time-range** diff on both heap types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
