### PR TITLE
feat: update password reset logic to respect DISABLE_PASSWORD_LOGIN setting

### DIFF
--- a/backend/app/config/config.go
+++ b/backend/app/config/config.go
@@ -128,6 +128,13 @@ func PollSeconds(value string, defaultSeconds int) time.Duration {
 	return time.Duration(seconds) * time.Second
 }
 
+// PasswordLoginDisabled reports whether the instance is SSO-only
+// (DISABLE_PASSWORD_LOGIN=true), which turns off password login,
+// registration, and the password-reset flow.
+func (c *Cfg) PasswordLoginDisabled() bool {
+	return c.DisablePasswordLogin == "true"
+}
+
 // TwilioEnabled reports whether SMS sending is configured: account credentials
 // plus at least one sender (a from-number or a messaging service).
 func (c *Cfg) TwilioEnabled() bool {

--- a/backend/app/controllers/auth.controller.go
+++ b/backend/app/controllers/auth.controller.go
@@ -17,6 +17,8 @@ import (
 
 var PostRegistrationHooks []func(tx *sql.Tx, org *models.Organization, user *models.User) error
 
+const passwordLoginDisabledMessage = "Password login is disabled. Please use SSO to sign in."
+
 type authController struct{}
 
 func (a authController) HasOrganizations(c *gin.Context) {
@@ -32,8 +34,8 @@ func (a authController) HasOrganizations(c *gin.Context) {
 }
 
 func (a authController) Login(c *gin.Context) {
-	if config.Config.DisablePasswordLogin == "true" {
-		c.JSON(http.StatusForbidden, gin.H{"error": "Password login is disabled. Please use SSO to sign in."})
+	if config.Config.PasswordLoginDisabled() {
+		c.JSON(http.StatusForbidden, gin.H{"error": passwordLoginDisabledMessage})
 		return
 	}
 
@@ -87,8 +89,8 @@ func (a authController) Login(c *gin.Context) {
 }
 
 func (a authController) Register(c *gin.Context) {
-	if config.Config.DisablePasswordLogin == "true" {
-		c.JSON(http.StatusForbidden, gin.H{"error": "Password login is disabled. Please use SSO to sign in."})
+	if config.Config.PasswordLoginDisabled() {
+		c.JSON(http.StatusForbidden, gin.H{"error": passwordLoginDisabledMessage})
 		return
 	}
 

--- a/backend/app/controllers/oauth.controller.go
+++ b/backend/app/controllers/oauth.controller.go
@@ -39,7 +39,7 @@ type finishOAuthSetupRequest struct {
 }
 
 func (a oauthController) ListProviders(c *gin.Context) {
-	passwordEnabled := config.Config.DisablePasswordLogin != "true"
+	passwordEnabled := !config.Config.PasswordLoginDisabled()
 	if services.OAuthService == nil {
 		c.JSON(http.StatusOK, oauthProvidersResponse{Providers: []string{}, ProviderLabels: map[string]string{}, PasswordLoginEnabled: passwordEnabled})
 		return

--- a/backend/app/controllers/password_reset.controller.go
+++ b/backend/app/controllers/password_reset.controller.go
@@ -22,8 +22,8 @@ const resetTokenExpiry = 1 * time.Hour
 const resetRateLimitPeriod = 1 * time.Hour
 
 func (c *passwordResetController) ForgotPassword(ctx *gin.Context) {
-	if config.Config.DisablePasswordLogin == "true" {
-		ctx.JSON(http.StatusForbidden, gin.H{"error": "Password login is disabled. Please use SSO to sign in."})
+	if config.Config.PasswordLoginDisabled() {
+		ctx.JSON(http.StatusForbidden, gin.H{"error": passwordLoginDisabledMessage})
 		return
 	}
 
@@ -70,8 +70,8 @@ func (c *passwordResetController) ForgotPassword(ctx *gin.Context) {
 }
 
 func (c *passwordResetController) ValidateToken(ctx *gin.Context) {
-	if config.Config.DisablePasswordLogin == "true" {
-		ctx.JSON(http.StatusForbidden, gin.H{"error": "Password login is disabled. Please use SSO to sign in."})
+	if config.Config.PasswordLoginDisabled() {
+		ctx.JSON(http.StatusForbidden, gin.H{"error": passwordLoginDisabledMessage})
 		return
 	}
 
@@ -103,8 +103,8 @@ func (c *passwordResetController) ValidateToken(ctx *gin.Context) {
 }
 
 func (c *passwordResetController) ResetPassword(ctx *gin.Context) {
-	if config.Config.DisablePasswordLogin == "true" {
-		ctx.JSON(http.StatusForbidden, gin.H{"error": "Password login is disabled. Please use SSO to sign in."})
+	if config.Config.PasswordLoginDisabled() {
+		ctx.JSON(http.StatusForbidden, gin.H{"error": passwordLoginDisabledMessage})
 		return
 	}
 

--- a/backend/app/controllers/password_reset.controller.go
+++ b/backend/app/controllers/password_reset.controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"database/sql"
 	"fmt"
+	"github.com/tracewayapp/traceway/backend/app/config"
 	"github.com/tracewayapp/traceway/backend/app/db"
 	"github.com/tracewayapp/traceway/backend/app/models"
 	"github.com/tracewayapp/traceway/backend/app/repositories/transactional"
@@ -21,6 +22,11 @@ const resetTokenExpiry = 1 * time.Hour
 const resetRateLimitPeriod = 1 * time.Hour
 
 func (c *passwordResetController) ForgotPassword(ctx *gin.Context) {
+	if config.Config.DisablePasswordLogin == "true" {
+		ctx.JSON(http.StatusForbidden, gin.H{"error": "Password login is disabled. Please use SSO to sign in."})
+		return
+	}
+
 	tx := db.GetTx(ctx)
 
 	var request models.ForgotPasswordRequest
@@ -64,6 +70,11 @@ func (c *passwordResetController) ForgotPassword(ctx *gin.Context) {
 }
 
 func (c *passwordResetController) ValidateToken(ctx *gin.Context) {
+	if config.Config.DisablePasswordLogin == "true" {
+		ctx.JSON(http.StatusForbidden, gin.H{"error": "Password login is disabled. Please use SSO to sign in."})
+		return
+	}
+
 	token := ctx.Param("token")
 
 	user, err := db.ExecuteTransaction(func(tx *sql.Tx) (*models.User, error) {
@@ -92,6 +103,11 @@ func (c *passwordResetController) ValidateToken(ctx *gin.Context) {
 }
 
 func (c *passwordResetController) ResetPassword(ctx *gin.Context) {
+	if config.Config.DisablePasswordLogin == "true" {
+		ctx.JSON(http.StatusForbidden, gin.H{"error": "Password login is disabled. Please use SSO to sign in."})
+		return
+	}
+
 	tx := db.GetTx(ctx)
 	token := ctx.Param("token")
 

--- a/frontend/src/routes/forgot-password/+page.svelte
+++ b/frontend/src/routes/forgot-password/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
+	import { onMount } from 'svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
@@ -13,6 +15,21 @@
 	let error = $state('');
 	let loading = $state(false);
 	let success = $state(false);
+
+	onMount(async () => {
+		try {
+			const response = await fetch('/api/auth/providers');
+			if (response.ok) {
+				const data = await response.json();
+				// password login disabled, so just skip this entirely and redirect to SSO login
+				if (data.passwordLoginEnabled === false) {
+					goto(resolve('/login'));
+				}
+			}
+		} catch {
+			// leave the page usable even if we manage to get here since we still have the backend check
+		}
+	});
 
 	async function handleSubmit() {
 		loading = true;


### PR DESCRIPTION
The password reset controller currently exposes endpoints when password login is disabled. This PR adds basic guard logic to 403 all of these endpoints appropriately when this setting is set.