### PR TITLE
feat: rate limit unauthenticated auth endpoints per IP

### DIFF
--- a/backend/app/controllers/routes.go
+++ b/backend/app/controllers/routes.go
@@ -170,19 +170,23 @@ func RegisterControllers(router *gin.RouterGroup) {
 	router.POST("/exception-stack-traces/by-id/:exceptionId", middleware.UseAppAuth, middleware.RequireProjectAccess, ExceptionStackTraceController.FindById)
 	router.POST("/exception-stack-traces/:hash", middleware.UseAppAuth, middleware.RequireProjectAccess, ExceptionStackTraceController.FindByHash)
 
-	router.POST("/login", middleware.Transactional, AuthController.Login)
-	router.POST("/register", middleware.Transactional, AuthController.Register)
+	// Keep the limiter before Transactional so rejected requests don't open a transaction.
+	router.POST("/login", middleware.RateLimitPerIP(10, time.Minute), middleware.Transactional, AuthController.Login)
+	router.POST("/register", middleware.RateLimitPerIP(10, time.Minute), middleware.Transactional, AuthController.Register)
 	router.GET("/me/login-bundle", middleware.UseAppAuth, middleware.Transactional, AuthController.LoginBundle)
 
 	router.GET("/auth/providers", OAuthController.ListProviders)
-	router.GET("/auth/start/:provider", middleware.Transactional, OAuthController.Begin)
-	router.GET("/auth/callback/:provider", middleware.Transactional, OAuthController.Callback)
+	router.GET("/auth/start/:provider", middleware.RateLimitPerIP(20, time.Minute), middleware.Transactional, OAuthController.Begin)
+	router.GET("/auth/callback/:provider", middleware.RateLimitPerIP(20, time.Minute), middleware.Transactional, OAuthController.Callback)
 	router.POST("/auth/finish-setup", middleware.UseAppAuth, middleware.Transactional, OAuthController.FinishSetup)
 
 	router.Match(postPreflight, "/auth/device/authorize", middleware.OAuthCors, middleware.RateLimitPerIP(10, time.Minute), DeviceAuthController.Authorize)
-	router.Match(postPreflight, "/auth/device/token", middleware.OAuthCors, DeviceAuthController.Token)
-	router.Match(postPreflight, "/auth/token", middleware.OAuthCors, DeviceAuthController.Token)
-	router.Match(postPreflight, "/auth/logout", middleware.OAuthCors, DeviceAuthController.Logout)
+	// One shared limiter instance so both token routes draw from the same budget;
+	// slightly higher 60/min limit to leave headroom for concurrent device flow polling behind NAT
+	tokenRateLimit := middleware.RateLimitPerIP(60, time.Minute)
+	router.Match(postPreflight, "/auth/device/token", middleware.OAuthCors, tokenRateLimit, DeviceAuthController.Token)
+	router.Match(postPreflight, "/auth/token", middleware.OAuthCors, tokenRateLimit, DeviceAuthController.Token)
+	router.Match(postPreflight, "/auth/logout", middleware.OAuthCors, middleware.RateLimitPerIP(20, time.Minute), DeviceAuthController.Logout)
 	router.GET("/device", middleware.UseAppAuth, DeviceAuthController.Lookup)
 	router.POST("/device/approve", middleware.UseAppAuth, middleware.Transactional, DeviceAuthController.Approve)
 	router.POST("/device/deny", middleware.UseAppAuth, middleware.Transactional, DeviceAuthController.Deny)
@@ -212,9 +216,10 @@ func RegisterControllers(router *gin.RouterGroup) {
 		router.GET("/has-organizations", middleware.Transactional, AuthController.HasOrganizations)
 	}
 
-	router.POST("/forgot-password", middleware.Transactional, PasswordResetController.ForgotPassword)
-	router.GET("/password-reset/:token", PasswordResetController.ValidateToken)
-	router.POST("/password-reset/:token", middleware.Transactional, PasswordResetController.ResetPassword)
+	// slightly tighter limit since every accepted request sends an email
+	router.POST("/forgot-password", middleware.RateLimitPerIP(5, time.Minute), middleware.Transactional, PasswordResetController.ForgotPassword)
+	router.GET("/password-reset/:token", middleware.RateLimitPerIP(30, time.Minute), PasswordResetController.ValidateToken)
+	router.POST("/password-reset/:token", middleware.RateLimitPerIP(10, time.Minute), middleware.Transactional, PasswordResetController.ResetPassword)
 
 	router.GET("/organizations/:organizationId/settings", middleware.UseAppAuth, middleware.RequireAdminAccess, OrganizationController.GetSettings)
 	router.PUT("/organizations/:organizationId/settings", middleware.UseAppAuth, middleware.RequireAdminAccess, middleware.Transactional, OrganizationController.UpdateSettings)
@@ -229,8 +234,8 @@ func RegisterControllers(router *gin.RouterGroup) {
 	router.GET("/organizations/:organizationId/invitations", middleware.UseAppAuth, middleware.RequireAdminAccess, InvitationController.ListInvitations)
 	router.DELETE("/organizations/:organizationId/invitations/:id", middleware.UseAppAuth, middleware.RequireAdminAccess, middleware.Transactional, InvitationController.RevokeInvitation)
 
-	router.GET("/invitations/:token", InvitationController.GetInvitationInfo)
-	router.POST("/invitations/:token/accept", middleware.Transactional, InvitationController.AcceptInvitation)
+	router.GET("/invitations/:token", middleware.RateLimitPerIP(30, time.Minute), InvitationController.GetInvitationInfo)
+	router.POST("/invitations/:token/accept", middleware.RateLimitPerIP(10, time.Minute), middleware.Transactional, InvitationController.AcceptInvitation)
 	router.POST("/invitations/:token/accept-existing", middleware.UseAppAuth, middleware.Transactional, InvitationController.AcceptExistingUser)
 
 	router.POST("/projects/source-map-token", middleware.UseAppAuth, middleware.RequireProjectAccess, middleware.RequireWriteAccess, ProjectController.GenerateSourceMapToken)


### PR DESCRIPTION
## Description
Traceway currently has no rate limits on `/forgot-password`, `/password-reset`, `/invitations/*`,
or the core login/registration endpoints. This leaves the API surface open to adversarial attacks
to brute-force credentials, enumerate invitation and reset tokens, or drive unbounded email sends.

This PR adds fixed-window per-IP limits using the existing in-memory `RateLimitPerIP` middleware
(already used by device-authorize, status pages, and ack links), with reasonable limits. Although
these limits are not yet configurable,

note: this PR was AI-assisted to identify the routes with missing rate-limits handlers; code has been reviewed prior to submission.

## Limits

| Endpoint | Limit | Rationale |
|---|---|---|
| `POST /login`, `POST /register` | 10/min | Interactive logins are rare; lockout lasts at most a minute |
| `GET /auth/start\|callback/:provider` | 20/min | SSO redirects can retry/bounce |
| `POST /auth/token`, `/auth/device/token` | 60/min shared | Headroom for concurrent device-flow polling behind NAT; both routes draw from one limiter instance |
| `POST /auth/logout` | 20/min | |
| `POST /forgot-password` | 5/min | Every accepted request sends an email |
| `GET/POST /password-reset/:token` | 30 / 10 per min | Token validation vs. consumption |
| `GET /invitations/:token`, `POST .../accept` | 30 / 10 per min | Token enumeration guard |

## Notes for review

- Limiters are placed **before** `middleware.Transactional`, so throttled requests never open a DB transaction.
- Fixed-window semantics: up to 2x the budget can pass across a window boundary. Fine for these endpoints.
- Known limitation, deferred to a follow-up: gin trusts `X-Forwarded-For` from any peer by default, so per-IP keying is spoofable by direct clients. This weakness already exists for the endpoints rate-limited on `main`; a `TRUSTED_PROXIES` hardening PR can follow-up to improve this.
- The rate-limiter is in-memory, so budgets are per-process and reset on restart — full protection for single-instance deployments (the common self-hosted case); multi-replica sharing lands in a later PR.

