### PR TITLE
docs: correct backend entry point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,13 @@ Traceway is an error tracking and monitoring platform consisting of:
 | Frontend | `cd frontend && npm run dev` | Dev server (port 5173) |
 | Frontend | `npm run build` | Production build |
 | Frontend | `npm run check` | TypeScript checking |
-| Backend | `cd backend && go run .` | API server (port 8082) |
+| Backend | `cd backend && go run ./cmd/traceway` | API server (port 8082) |
 | CLI | `cd cli && just build` | Builds `bin/traceway` |
 | CLI | `cd cli && just test` | Runs unit tests |
 | CLI | `cd cli && just check` | Lint + test + vulncheck (pre-commit gate) |
 | CLI | `cd cli && just smoke-test` | Live E2E (needs `TRACEWAY_SMOKE_*` env vars) |
+
+Set `JWT_SECRET` (min 32 characters) before running the backend — it is the one variable with no default. `SQLITE_PATH` sets the database location, defaulting to `./traceway.db` in the working directory.
 
 ### Tech Stack
 - **Frontend**: SvelteKit 2.49, Svelte 5.45, Tailwind CSS v4, shadcn-svelte, Vite 7
@@ -538,7 +540,11 @@ Uses shadcn-svelte registry with bits-ui primitives. Key components:
 ### Project Structure
 ```
 backend/
-├── main.go                     # Entry point, DB init, server start
+├── traceway.go                 # package tracewaybackend - embeddable API (Run, WithPort, ...)
+├── cmd/
+│   ├── run.go                  # Run() implementation: DB init, routes, server start
+│   ├── traceway/main.go        # Binary entry point (package main)
+│   └── traceway-runner/        # Synthetics remote runner binary
 ├── app/
 │   ├── controllers/
 │   │   ├── routes.go           # Route registration

--- a/scripts/build-oxc-shim.sh
+++ b/scripts/build-oxc-shim.sh
@@ -14,5 +14,5 @@ cargo build --release
 
 echo "Built liboxc_shim.a"
 echo "Build the backend with the oxc parser enabled:"
-echo "  cd backend && go build -tags oxc ."
+echo "  cd backend && go build -tags oxc ./cmd/traceway"
 echo "Select it at runtime with SYMBOLICATOR_PARSER=oxc"


### PR DESCRIPTION
## What

`CLAUDE.md`'s Quick Start pointed at `cd backend && go run .` and listed `backend/main.go` as the entry point. Neither exists.

`backend/` is `package tracewaybackend` — a library facade over `cmd`. So:

- `go run .` fails outright
- `go build -o x .` **exits 0 while silently emitting a `!<arch>` static archive** instead of a binary

The real entry point is `./cmd/traceway`.

## Changes

- Quick Start: `go run .` → `go run ./cmd/traceway`
- Project-structure tree: replaces the phantom `backend/main.go` with `traceway.go`, `cmd/run.go`, `cmd/traceway/main.go`, and `cmd/traceway-runner/`
- `scripts/build-oxc-shim.sh` printed the identical stale command. That one matters more than it looks — the `oxc` dev shell in #302 points developers straight at this script.
- Notes that `JWT_SECRET` must be set before the backend starts

## Verification

`go build -o x ./cmd/traceway` produces a 90MB ELF executable; the old form produces a 78KB archive.

## Merge order

⚠️ **Best merged after #305.** An earlier revision of this PR also documented `DB_TYPE=sqlite` and `PORTS=8082` as required, because the backend panicked twice without them. #305 removes both panics, so that guidance has been trimmed out and only `JWT_SECRET` remains.

If this lands *before* #305, the Quick Start command will still panic on `DB_TYPE` and `:80` and the docs won't say so. Landing #305 first makes this page accurate immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)