### PR TITLE
ci: test the backend on every PR

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,241 @@
+name: Backend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      # backend/go.mod `replace`s the local cli module and app/services/mcpmount
+      # imports cli/pkg/{client,mcpserver}, so a cli-only change can break the
+      # backend build. cli.yml already lists backend/** for the same reason.
+      - "cli/**"
+      - ".github/workflows/backend.yml"
+  pull_request:
+    paths:
+      - "backend/**"
+      - "cli/**"
+      - ".github/workflows/backend.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  sqlite:
+    name: Test (dual SQLite)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          # Cached per build-tag set below instead: setup-go keys only on
+          # go.sum, which is identical across these three jobs, so they would
+          # race for one key and the winner's cache would then be frozen --
+          # leaving the duckdb job to re-fetch ~131MB of libduckdb every run.
+          cache: false
+
+      - name: Cache Go modules and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-${{ runner.os }}-sqlite-${{ hashFiles('backend/go.sum') }}
+          restore-keys: go-${{ runner.os }}-sqlite-
+
+      # CGO_ENABLED=0 mirrors Dockerfile.sqlite, so CI links what ships.
+      - name: Build
+        env:
+          CGO_ENABLED: "0"
+        run: go build ./cmd/traceway ./cmd/traceway-runner
+
+      # release-traceway.yml cross-builds the runner for linux/darwin/windows,
+      # but app/synthetics/browserexec/proc_windows.go is `//go:build windows`
+      # and compiles in no other job -- editing its proc_unix.go sibling would
+      # break the release build with every PR check still green.
+      - name: Cross-compile runner for released platforms
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          for target in "windows amd64" "darwin arm64" "linux arm64"; do
+            set -- $target
+            echo "  $1/$2"
+            GOOS=$1 GOARCH=$2 go build -o /dev/null ./cmd/traceway-runner
+          done
+
+      # The race detector requires cgo, so this step cannot inherit the
+      # CGO_ENABLED=0 above. Worth the divergence: the backend runs the outbox
+      # drain, on-call escalator, synthetics scheduler and recordings uploader
+      # as long-lived goroutines over shared state.
+      - name: Test
+        env:
+          CGO_ENABLED: "1"
+        run: go test -race -count=1 ./...
+
+  duckdb:
+    name: Test (DuckDB telemetry)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      # duckdb-go bundles prebuilt static libs for glibc and needs cgo;
+      # mirrors Dockerfile.duckdb.
+      CGO_ENABLED: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache: false
+
+      - name: Cache Go modules and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-${{ runner.os }}-duckdb-${{ hashFiles('backend/go.sum') }}
+          restore-keys: go-${{ runner.os }}-duckdb-
+
+      # Load-bearing, not redundant with the tests below: the test scope covers
+      # two package trees, so this is what compiles the other ~47 packages under
+      # this tag.
+      - name: Build
+        run: go build -tags telemetry_duckdb ./cmd/traceway ./cmd/traceway-runner
+
+      # The DuckDB harness opens an in-memory database, so no service
+      # containers are needed. app/retention is included because
+      # log_cap_duckdb_test.go is `//go:build telemetry_duckdb` and would
+      # otherwise run in no job at all -- the untagged job compiles it out.
+      # The scope is deliberately not ./... : three packages fail under this
+      # tag today, which is a separate problem from this workflow.
+      - name: Test
+        run: go test -tags telemetry_duckdb -count=1 ./app/repositories/... ./app/retention/...
+
+  pgch:
+    name: Test (PostgreSQL + ClickHouse)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: backend
+
+    # Same images docker-compose.yml pins, so CI exercises what is shipped.
+    # start-period mirrors compose: without it, probes fired during postgres
+    # initdb (which runs a socket-only server first) count against the retry
+    # budget and can report healthy before TCP is actually up.
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: traceway
+          POSTGRES_PASSWORD: traceway
+          POSTGRES_DB: traceway_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U traceway"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-start-period 10s
+          --health-retries 10
+
+      clickhouse:
+        image: clickhouse/clickhouse-server:24.8-alpine
+        env:
+          CLICKHOUSE_DB: traceway_test
+        ports:
+          - 8123:8123
+          - 9000:9000
+        options: >-
+          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:8123/ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-start-period 10s
+          --health-retries 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache: false
+
+      - name: Cache Go modules and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-${{ runner.os }}-pgch-${{ hashFiles('backend/go.sum') }}
+          restore-keys: go-${{ runner.os }}-pgch-
+
+      # CGO_ENABLED=0 mirrors Dockerfile and Dockerfile.minimal.
+      - name: Build
+        env:
+          CGO_ENABLED: "0"
+        run: go build -tags "transactional_pg telemetry_ch" ./cmd/traceway ./cmd/traceway-runner
+
+      # Migrations are applied over ClickHouse's HTTP interface rather than with
+      # clickhouse-client, which is not on the runner. Every file in
+      # migrations/ch holds exactly one statement (the golang-migrate ClickHouse
+      # driver is built with MultiStatementEnabled: false), so one request per
+      # file is the whole contract, and it keeps per-file error attribution.
+      #
+      # Unlike scripts/test-pgch-entrypoint.sh these are NOT suffixed with
+      # `|| true`: a migration that fails there silently yields a half-built
+      # schema and surfaces later as confusing test failures.
+      - name: Apply ClickHouse migrations
+        run: |
+          for f in app/migrations/ch/*.up.sql; do
+            echo "  ${f##*/}"
+            curl -sS --fail-with-body 'http://localhost:8123/?database=traceway_test' \
+              --data-binary "@$f"
+          done
+
+      # Piped into a single psql rather than one process per file: postgres:17
+      # defaults to scram-sha-256, so 141 connections means 141 PBKDF2
+      # handshakes. \echo above each \i preserves per-file attribution, and
+      # ON_ERROR_STOP=1 still aborts at the first failure.
+      - name: Apply PostgreSQL migrations
+        env:
+          PGPASSWORD: traceway
+        run: |
+          for f in app/migrations/pg/*.up.sql; do
+            printf '\\echo :: %s\n\\i %s\n' "${f##*/}" "$f"
+          done | psql -v ON_ERROR_STOP=1 -h localhost -U traceway -d traceway_test -f -
+
+      # setupTestDB skips unless TEST_CLICKHOUSE_SERVER is set, so these are
+      # what opts the tagged suite in -- without them the job would report ok
+      # while running nothing. app/chdb is included because batch_retry_test.go
+      # is `//go:build telemetry_ch` and would otherwise run in no job at all;
+      # it uses fakes and needs no live ClickHouse.
+      - name: Test
+        env:
+          CGO_ENABLED: "0"
+          TEST_CLICKHOUSE_SERVER: localhost:9000
+          TEST_CLICKHOUSE_DATABASE: traceway_test
+          TEST_POSTGRES_HOST: localhost
+          TEST_POSTGRES_DATABASE: traceway_test
+          TEST_POSTGRES_USERNAME: traceway
+          TEST_POSTGRES_PASSWORD: traceway
+        run: go test -tags "transactional_pg telemetry_ch" -count=1 ./app/repositories/... ./app/chdb/...

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -137,9 +137,9 @@ jobs:
         working-directory: backend
 
     # Same images docker-compose.yml pins, so CI exercises what is shipped.
-    # start-period mirrors compose: without it, probes fired during postgres
-    # initdb (which runs a socket-only server first) count against the retry
-    # budget and can report healthy before TCP is actually up.
+    # postgres keeps a start-period, mirroring compose: without it, probes fired
+    # during initdb (which runs a socket-only server first) count against the
+    # retry budget and can report healthy before TCP is actually up.
     services:
       postgres:
         image: postgres:17
@@ -156,25 +156,28 @@ jobs:
           --health-start-period 10s
           --health-retries 10
 
-      # Deliberately NOT using the image's CLICKHOUSE_DB env var, even though
-      # docker-compose.yml does and it would replace the explicit creation step
-      # below. Setting it makes the entrypoint run its first-boot init path,
-      # which (with no CLICKHOUSE_USER/PASSWORD set) also disables network
-      # access for the default user; on a GitHub runner the container then never
-      # reports healthy and the job dies in "Initialize containers" before a
-      # single step runs. It recovers locally under podman, so this is not
-      # reproducible off-runner -- please don't re-simplify it.
+      # CLICKHOUSE_SKIP_USER_SETUP keeps the image's stock users.xml, whose
+      # `default` user accepts ::/0. Without it the entrypoint overwrites
+      # default-user.xml with <networks>::1, 127.0.0.1</networks> -- the
+      # "disabling network access for user 'default'" line in the container log
+      # -- which locks out every connection this job makes: they all arrive from
+      # the runner over the published port, so ClickHouse sees the bridge
+      # gateway address, not localhost.
+      #
+      # No --health-cmd on purpose. A healthcheck that never passes kills the job
+      # in "Initialize containers", before a single step runs, and the only
+      # diagnostic left is the word "unhealthy" plus the container's stdout --
+      # four lines of preamble, because ClickHouse logs to files. The wait step
+      # below polls the published port instead: it checks what this job actually
+      # needs (reachability from the runner, not from inside the container) and
+      # leaves any failure inside a step that can print the server's real log.
       clickhouse:
         image: clickhouse/clickhouse-server:24.8-alpine
+        env:
+          CLICKHOUSE_SKIP_USER_SETUP: "1"
         ports:
           - 8123:8123
           - 9000:9000
-        options: >-
-          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:8123/ping"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-start-period 10s
-          --health-retries 20
 
     steps:
       - name: Checkout
@@ -201,12 +204,28 @@ jobs:
           CGO_ENABLED: "0"
         run: go build -tags "transactional_pg telemetry_ch" ./cmd/traceway ./cmd/traceway-runner
 
+      # Placed after the build so ClickHouse warms up while Go compiles, and at
+      # the first query rather than at the top of the job.
+      - name: Wait for ClickHouse
+        run: |
+          for i in $(seq 1 90); do
+            if curl -sfo /dev/null 'http://localhost:8123/ping'; then
+              echo "ClickHouse answered /ping after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::ClickHouse never answered /ping on localhost:8123"
+          cid=$(docker ps -aq --filter 'ancestor=clickhouse/clickhouse-server:24.8-alpine' | head -1)
+          docker logs "$cid" || true
+          docker exec "$cid" tail -n 100 /var/log/clickhouse-server/clickhouse-server.err.log || true
+          exit 1
+
       # Migrations are applied over ClickHouse's HTTP interface rather than with
       # clickhouse-client, which is not on the runner. Every file in
       # migrations/ch holds exactly one statement (the golang-migrate ClickHouse
       # driver is built with MultiStatementEnabled: false), so one request per
       # file is the whole contract, and it keeps per-file error attribution.
-      #
       - name: Create ClickHouse database
         run: |
           curl -sS --fail-with-body 'http://localhost:8123/' \

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -156,10 +156,16 @@ jobs:
           --health-start-period 10s
           --health-retries 10
 
+      # Deliberately NOT using the image's CLICKHOUSE_DB env var, even though
+      # docker-compose.yml does and it would replace the explicit creation step
+      # below. Setting it makes the entrypoint run its first-boot init path,
+      # which (with no CLICKHOUSE_USER/PASSWORD set) also disables network
+      # access for the default user; on a GitHub runner the container then never
+      # reports healthy and the job dies in "Initialize containers" before a
+      # single step runs. It recovers locally under podman, so this is not
+      # reproducible off-runner -- please don't re-simplify it.
       clickhouse:
         image: clickhouse/clickhouse-server:24.8-alpine
-        env:
-          CLICKHOUSE_DB: traceway_test
         ports:
           - 8123:8123
           - 9000:9000
@@ -201,6 +207,11 @@ jobs:
       # driver is built with MultiStatementEnabled: false), so one request per
       # file is the whole contract, and it keeps per-file error attribution.
       #
+      - name: Create ClickHouse database
+        run: |
+          curl -sS --fail-with-body 'http://localhost:8123/' \
+            --data-binary 'CREATE DATABASE IF NOT EXISTS traceway_test'
+
       # Unlike scripts/test-pgch-entrypoint.sh these are NOT suffixed with
       # `|| true`: a migration that fails there silently yields a half-built
       # schema and surfaces later as confusing test failures.

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -259,6 +259,12 @@ jobs:
       # while running nothing. app/chdb is included because batch_retry_test.go
       # is `//go:build telemetry_ch` and would otherwise run in no job at all;
       # it uses fakes and needs no live ClickHouse.
+      #
+      # -json is written to a file for the tally below and replayed through jq
+      # so the log still reads like ordinary `go test` output. pipefail is set
+      # explicitly: the default shell here is `bash -e`, which takes the exit
+      # status of the last command in a pipeline -- without it jq's success
+      # would mask a failing test run.
       - name: Test
         env:
           CGO_ENABLED: "0"
@@ -268,4 +274,43 @@ jobs:
           TEST_POSTGRES_DATABASE: traceway_test
           TEST_POSTGRES_USERNAME: traceway
           TEST_POSTGRES_PASSWORD: traceway
-        run: go test -tags "transactional_pg telemetry_ch" -count=1 ./app/repositories/... ./app/chdb/...
+        run: |
+          set -o pipefail
+          go test -json -tags "transactional_pg telemetry_ch" -count=1 \
+            ./app/repositories/... ./app/chdb/... \
+            | tee "$RUNNER_TEMP/pgch-tests.jsonl" \
+            | jq -j 'select(.Action == "output") | .Output'
+
+      # Green and "ran something" are not the same claim here. Every test in
+      # this suite reaches live ClickHouse and PostgreSQL through setupTestDB,
+      # which calls t.Skip when TEST_CLICKHOUSE_SERVER is missing -- and a
+      # package whose every test skipped still prints "ok". Dropping one env
+      # var above would leave this job passing while asserting nothing, which
+      # is the one failure mode a test workflow must not have.
+      #
+      # Package-level "skip" events (the `[no test files]` packages) carry no
+      # .Test field and are excluded; only skipped *tests* count. If a
+      # deliberately skippable test is ever added here, exclude it by name
+      # rather than deleting the guard.
+      #
+      # The pass tally counts top-level tests only -- subtests emit their own
+      # pass events, and a count inflated by them could not be compared against
+      # the suite size. Skips are counted at every level, subtests included.
+      - name: Assert the suite actually ran
+        run: |
+          results="$RUNNER_TEMP/pgch-tests.jsonl"
+          skipped=$(jq -r 'select(.Action == "skip" and .Test != null) | "\(.Package) \(.Test)"' "$results")
+          passed=$(jq -r 'select(.Action == "pass" and .Test != null and (.Test | contains("/") | not)) | .Test' "$results" | wc -l)
+
+          if [ -n "$skipped" ]; then
+            echo "::error::pgch suite skipped $(printf '%s\n' "$skipped" | wc -l) test(s) -- it must run against the service containers, not skip past them"
+            printf '%s\n' "$skipped"
+            exit 1
+          fi
+
+          if [ "$passed" -eq 0 ]; then
+            echo "::error::pgch suite ran no tests at all"
+            exit 1
+          fi
+
+          echo "$passed tests ran, 0 skipped"


### PR DESCRIPTION
## The gap

**No workflow runs the backend test suite.** `cli.yml` and `cli-contract.yml` are the only ones invoking `go test`, and both run with `working-directory: cli`. Backend changes *trigger* `cli.yml` via its path filter, but that job tests the CLI — the backend is exercised only indirectly, through the contract harness booting it in-process on in-memory SQLite.

The `transactional_pg telemetry_ch` build — what the released image ships — was verified only when someone remembered to run `scripts/test-backend-pgch.sh` on a machine with Docker.

## Three jobs, one per supported build-tag combination

| Job | Scope |
|---|---|
| `sqlite` | `go test -race ./...` + cross-compile the runner |
| `duckdb` | `-tags telemetry_duckdb`, in-memory, no services |
| `pgch` | service containers on the images `docker-compose.yml` pins |

## Verified before opening this

Run locally against **rootless podman** with the same two images:

- **84/84 ClickHouse migrations** and **141/141 PostgreSQL migrations** apply, with failures surfaced rather than swallowed
- **The tagged suite is green: 80 tests run, 80 pass, 0 skipped**

That last detail matters. `setupTestDB` skips when `TEST_CLICKHOUSE_SERVER` is unset, and a skipped package still reports `ok` — so a naive run looks green either way. I checked the skip count explicitly: 80 `=== RUN`, 80 `--- PASS`.

So **the ClickHouse production build is currently healthy**, which is why `pgch` blocks rather than starting advisory: a red run later means a real regression, not pre-existing rot.

## Decisions worth reviewing

**Test scope is a list, not `./...`.** `app/chdb/batch_retry_test.go` is `//go:build telemetry_ch` and `app/retention/log_cap_duckdb_test.go` is `//go:build telemetry_duckdb` — under the scope this was first modelled on (`scripts/test-pgch-entrypoint.sh`), both ran in **no job at all**: the untagged job compiles them out, the tagged jobs never reach their packages. `./...` isn't usable for duckdb — three packages fail under that tag today, which is a separate problem.

**`cli/**` is in the path filter.** `backend/go.mod` has `replace github.com/tracewayapp/traceway/cli => ../cli` and `app/services/mcpmount` imports `cli/pkg/{client,mcpserver}`, so a cli-only change can break the backend build. `cli.yml` already lists `backend/**`; this wires up the other half of a symmetry the repo had already chosen.

**`CGO_ENABLED` is pinned per job** (`0` for sqlite/pgch, `1` for duckdb) to match each Dockerfile, so CI links what ships. The race step overrides back to `1` — the detector requires cgo, so release parity and race detection want opposite answers, and they're split rather than one being silently dropped.

**Go caches are keyed per tag set.** `setup-go` keys only on `go.sum`, which is identical across all three jobs — they'd race for a single key, and the winner's cache would then freeze on exact hits, leaving the duckdb job to refetch ~131MB of libduckdb every run.

**The runner is cross-compiled** for the platforms `release-traceway.yml` publishes. `app/synthetics/browserexec/proc_windows.go` is `//go:build windows` and compiles in no other job, so editing its `proc_unix.go` sibling would break the release build with every PR check still green.

**Migrations drop the `|| true`.** `scripts/test-pgch-entrypoint.sh` suffixes every migration with it, which silently yields a half-built schema. Both loops here fail loudly (`--fail-with-body`, `ON_ERROR_STOP=1`) — and I confirmed nothing actually fails, so the suppression protects against nothing.

## Follow-ups deliberately not in this PR

- **CI hand-applies migrations rather than calling `migrations.Run()`**, so it builds its schema by a path production never uses. Fixing it needs a migrate-only entrypoint — Go code, not YAML.
- **`scripts/test-pgch-entrypoint.sh` now disagrees with CI** on what a broken migration means. Dropping its `|| true` and adding `ON_ERROR_STOP=1` is a two-line change that makes "passes locally" mean the same as "passes in CI".

## Merge order

Independent of #301/#302/#303/#305 and safe to merge any time. Note it will run against those open PRs as soon as it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)