### PR TITLE
fix: exclude setup_test.go from the telemetry_duckdb build

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -135,20 +135,21 @@ jobs:
             go-${{ runner.os }}-duckdb-${{ hashFiles('backend/go.sum') }}-
             go-${{ runner.os }}-duckdb-
 
-      # Load-bearing, not redundant with the tests below: the test scope covers
-      # two package trees, so this is what compiles every other package under
-      # this tag.
+      # Retained even though the ./... test scope below compiles every package
+      # too: this fails fast with a plain build error before any test binary is
+      # linked, which is a clearer signal than a compile failure attributed to
+      # a test package.
       - name: Build
         run: go build -tags telemetry_duckdb ./...
 
       # The DuckDB harness opens an in-memory database, so no service
-      # containers are needed. app/retention is included because
-      # log_cap_duckdb_test.go is `//go:build telemetry_duckdb` and would
-      # otherwise run in no job at all -- the untagged job compiles it out.
-      # The scope is deliberately not ./... : three packages fail under this
-      # tag today, which is a separate problem from this workflow.
+      # containers are needed. The scope is ./... so that test files gated on
+      # this tag run somewhere at all -- app/retention/log_cap_duckdb_test.go
+      # and the telemetry_duckdb repository harness are compiled out of the
+      # untagged job, and app/controllers is where the missing !telemetry_duckdb
+      # constraint this commit fixes went unnoticed under the narrower scope.
       - name: Test
-        run: go test -tags telemetry_duckdb -count=1 ./app/repositories/... ./app/retention/...
+        run: go test -tags telemetry_duckdb -count=1 ./...
 
   pgch:
     name: Test (PostgreSQL + ClickHouse)

--- a/backend/app/controllers/setup_test.go
+++ b/backend/app/controllers/setup_test.go
@@ -1,4 +1,4 @@
-//go:build !telemetry_ch && !transactional_pg
+//go:build !telemetry_ch && !transactional_pg && !telemetry_duckdb
 
 package controllers
 


### PR DESCRIPTION
Closes #309.

## The bug

`app/controllers/setup_test.go` hardcodes SQLite handles for **both** `db.DB` and `db.TelemetryDB`, then calls `migrations.Run`. Under `-tags telemetry_duckdb` that dispatches to `duckdbTrackingDDL`:

```sql
CREATE TABLE IF NOT EXISTS schema_migrations (
	version VARCHAR PRIMARY KEY,
	applied_at TIMESTAMP DEFAULT now()
)
```

SQLite requires a parenthesised expression for a function default, so `DEFAULT now()` is a syntax error and all six tests in the file fail:

```
--- FAIL: TestBatchCreateProjectsCreatesAndIsIdempotent (0.03s)
    setup_test.go:106: run migrations: telemetry db migrations: failed to create
      schema_migrations table: SQL logic error: near "(": syntax error (1)
```

This is a missing build-constraint clause, not a migration bug — `migrations.Run` is correct against a real DuckDB handle.

## The fix

```diff
-//go:build !telemetry_ch && !transactional_pg
+//go:build !telemetry_ch && !transactional_pg && !telemetry_duckdb
```

Every sibling file that hardcodes SQLite handles already excludes the tag. `dashboard_template_seed_test.go`, in this same package, carries the correct three-clause form — this reads as a copy-paste that dropped a term.

### Why exclude rather than add a tagged DuckDB helper

The issue left this open. Excluding costs no real coverage: `transactional/transactional_sqlite.go` is tagged `!transactional_pg`, so under `-tags telemetry_duckdb` the transactional facade resolves to the *same* `transactional/sqlite` package as the default build. These six tests are main-DB only and never touch `db.TelemetryDB` beyond save/restore, so under DuckDB they were exercising byte-identical code. A helper would buy duplicate coverage at the cost of churn and divergence from six sibling files.

## Why CI didn't catch it

The DuckDB job's test scope skipped `app/controllers`:

```yaml
# The scope is deliberately not ./... : three packages fail under this
# tag today, which is a separate problem from this workflow.
run: go test -tags telemetry_duckdb -count=1 ./app/repositories/... ./app/retention/...
```

I measured that premise on `c7a5dcae`: **one** package fails under `-tags telemetry_duckdb ./...`, not three — this one. With the constraint fixed, the full tree passes, so the narrow scope has no remaining justification and this PR widens it to `./...`. Without that, the fix is never exercised and can silently rot.

Marginal cost, warm cache (the job already compiles every package under this tag in its Build step):

| Scope | Elapsed | Packages with tests |
|---|---|---|
| `./app/repositories/... ./app/retention/...` | 4s | 3 |
| `./...` | 7s | 31 |

## Verification

All three supported build-tag combinations, full tree:

| Combo | Command | Result |
|---|---|---|
| default (dual SQLite) | `go test ./...` | exit 0 |
| DuckDB telemetry | `CGO_ENABLED=1 go test -tags telemetry_duckdb ./...` | exit 0 |
| PostgreSQL + ClickHouse | `go test -tags "transactional_pg telemetry_ch" ./...` | exit 0 |

Production code is untouched; this is test-harness and CI only.

Note: CI here is label-gated, so a maintainer needs to apply the `ci` label for these jobs to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)