### PR TITLE
refactor: filter endpoint durations through endpointFilterClause

### DIFF
--- a/backend/app/repositories/telemetry/endpoint_repository_test.go
+++ b/backend/app/repositories/telemetry/endpoint_repository_test.go
@@ -582,3 +582,41 @@ func TestEndpointRepository_FindGroupedByEndpoint_RootFilterPercentiles(t *testi
 		t.Errorf("p95 = %v, want the root-only 100ms; non-root durations leaked into the percentile", stats[0].P95Duration)
 	}
 }
+
+// The chart ranks the top 5 on percentiles and then plots only the filtered
+// rows, so ranking on the unfiltered population puts endpoints on the chart that
+// are not slow under the filter. These two rank one way on all rows and the
+// other way on root rows alone.
+func TestEndpointRepository_GetEndpointStackedChart_RanksOnFilteredRows(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	projectId := uuid.New()
+	now := truncateMs(time.Now().UTC())
+
+	var endpoints []models.Endpoint
+	for range 3 {
+		// Slow as a root request, which is what "root" asks to see.
+		slowRoot := makeEndpoint(projectId, "GET /slow-root", 500*time.Millisecond, 200, now)
+		slowRoot.IsRoot = true
+		// Fast as a root request, slow only in the rows the filter drops.
+		fastRoot := makeEndpoint(projectId, "GET /fast-root", 10*time.Millisecond, 200, now)
+		fastRoot.IsRoot = true
+		endpoints = append(endpoints, slowRoot, fastRoot,
+			makeEndpoint(projectId, "GET /fast-root", 5*time.Second, 200, now))
+	}
+
+	if err := EndpointRepository.InsertAsync(ctx, endpoints); err != nil {
+		t.Fatalf("InsertAsync failed: %v", err)
+	}
+
+	chart, err := EndpointRepository.GetEndpointStackedChart(ctx, projectId, now.Add(-time.Hour), now.Add(time.Hour), 5, "p95", "", "root", "")
+	if err != nil {
+		t.Fatalf("GetEndpointStackedChart failed: %v", err)
+	}
+	if len(chart.Endpoints) < 2 {
+		t.Fatalf("expected both endpoints in the chart, got %v", chart.Endpoints)
+	}
+	if chart.Endpoints[0] != "GET /slow-root" {
+		t.Errorf("top endpoint ranked on unfiltered rows: got %v, want 'GET /slow-root' first", chart.Endpoints)
+	}
+}

--- a/backend/app/repositories/telemetry/sqlite/endpoint.repository.go
+++ b/backend/app/repositories/telemetry/sqlite/endpoint.repository.go
@@ -306,7 +306,7 @@ func (e *endpointRepository) FindGroupedByEndpoint(ctx context.Context, projectI
 			continue
 		}
 
-		durations, err := fetchSortedDurations(ctx, projectId, g.Endpoint, fromDate, toDate, rootFilter)
+		durations, err := fetchSortedDurations(ctx, projectId, g.Endpoint, fromDate, toDate, search, rootFilter, methodFilter)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -534,7 +534,7 @@ func (e *endpointRepository) FindWorstEndpoints(ctx context.Context, projectId u
 
 	var stats []models.EndpointStats
 	for _, g := range groups {
-		durations, err := fetchSortedDurations(ctx, projectId, g.Endpoint, start, end, "")
+		durations, err := fetchSortedDurations(ctx, projectId, g.Endpoint, start, end, "", "", "")
 		if err != nil {
 			return nil, err
 		}
@@ -616,7 +616,7 @@ func (e *endpointRepository) GetEndpointStats(ctx context.Context, projectId uui
 			stats.Apdex = row.SatisfiedTolerating / float64(row.Count)
 		}
 
-		durations, err := fetchSortedDurations(ctx, projectId, endpoint, start, end, "")
+		durations, err := fetchSortedDurations(ctx, projectId, endpoint, start, end, "", "", "")
 		if err != nil {
 			return nil, err
 		}
@@ -838,10 +838,17 @@ func (e *endpointRepository) UpsertSlowEndpoint(ctx context.Context, projectId u
 
 // --- helpers ---
 
-func fetchSortedDurations(ctx context.Context, projectId uuid.UUID, endpoint string, from, to time.Time, rootFilter string) ([]float64, error) {
+// fetchSortedDurations runs the same filter as the query that selected the
+// endpoint, via endpointFilterClause rather than picking out the one leg that
+// constrains rows today, so a row-level predicate added there cannot silently
+// leave the percentiles describing a different population.
+func fetchSortedDurations(ctx context.Context, projectId uuid.UUID, endpoint string, from, to time.Time, search, rootFilter, methodFilter string) ([]float64, error) {
+	params := lit.P{"project_id": projectId, "endpoint": endpoint, "from": sqlitetypes.NewSQLiteTime(from), "to": sqlitetypes.NewSQLiteTime(to)}
+	filterClause := endpointFilterClause(params, "", search, rootFilter, methodFilter)
+
 	results, err := lit.SelectNamed[endpointDurationRow](db.TelemetryDB,
-		"SELECT duration FROM endpoints WHERE project_id = :project_id AND endpoint = :endpoint AND recorded_at >= :from AND recorded_at <= :to AND is_stream = 0"+shared.RootFilterClause("is_root", rootFilter)+" ORDER BY duration ASC",
-		lit.P{"project_id": projectId, "endpoint": endpoint, "from": sqlitetypes.NewSQLiteTime(from), "to": sqlitetypes.NewSQLiteTime(to)})
+		"SELECT duration FROM endpoints WHERE project_id = :project_id AND endpoint = :endpoint AND recorded_at >= :from AND recorded_at <= :to AND is_stream = 0"+filterClause+" ORDER BY duration ASC",
+		params)
 	if err != nil {
 		return nil, err
 	}
@@ -923,7 +930,7 @@ func getTopEndpointsByMetric(ctx context.Context, projectId uuid.UUID, from, to 
 
 	var metrics []epMetric
 	for _, ep := range epRows {
-		durations, err := fetchSortedDurations(ctx, projectId, ep.Endpoint, from, to, rootFilter)
+		durations, err := fetchSortedDurations(ctx, projectId, ep.Endpoint, from, to, search, rootFilter, methodFilter)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**Rewritten.** This PR originally fixed the endpoint percentile/filter split described in #313. While it was in review, `95a65d24` landed that fix on `main` independently. The branch has been rebuilt on top of `main` and now contains only what is left over.

## What `main` already has

`95a65d24` threads `rootFilter` into `fetchSortedDurations` and splices `shared.RootFilterClause` directly, covering both `FindGroupedByEndpoint` and `getTopEndpointsByMetric`, plus a test for the grouped list. That is the bug fixed. Nothing here re-fixes it.

## What is left

**1. Route the duration query through `endpointFilterClause`.**

No behaviour change today: with the endpoint pinned by `endpoint = :endpoint`, the `search` and `method` legs cannot alter the row set, so `rootFilter` is the only load-bearing one. What it buys is that a row-level predicate added to `endpointFilterClause` reaches the percentile query automatically instead of silently applying to the selecting queries only.

Picking one leg out by hand is precisely how the original split happened — the grouping query used the full clause builder and the duration query used none. It is also the shape `sqlite/task.repository.go` and `sqlite/ai_trace.repository.go` land on in #319, so all three entities read the same way.

**2. A regression test for the chart ranking.**

`95a65d24` fixed `getTopEndpointsByMetric` alongside the grouped list, but only the grouped list got a test. The chart ranks its top 5 on percentiles and then plots only the filtered rows, so ranking on the unfiltered population puts endpoints on the chart that are not slow under the filter — a distinct symptom from the grouped list's wrong numbers.

**This test passes on `main`.** It guards the existing fix; it does not report a live bug. Flagging that explicitly so the green run is not mistaken for "reproduced and fixed".

## Verification

`go test -race -count=1 ./app/...`, the DuckDB-tagged repository suite, `go vet ./app/...`, `gofmt` — all clean. Test placement is the untagged `telemetry` package, so it runs against all three backends.

## Relationship to the others

- **#319** (tasks + AI traces) — the same defect class in two repositories `95a65d24` did not touch. Still a live fix, unaffected by this rewrite.
- **#320** (AI-trace stats error swallow) — independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)