### PR TITLE
fix: compute list percentiles over the filtered rows (tasks, AI traces, endpoints)

### DIFF
--- a/backend/app/repositories/telemetry/ai_trace_repository_test.go
+++ b/backend/app/repositories/telemetry/ai_trace_repository_test.go
@@ -508,8 +508,8 @@ func TestAiTraceRepository_ListModels(t *testing.T) {
 	}
 }
 
-// Same invariant as the tasks and endpoints lists: percentiles must describe the
-// rows the filter selects, since the list is ordered and paginated on them.
+// Percentiles must describe the rows the filter selects, since the list is
+// ordered and paginated on them.
 func TestAiTraceRepository_FindGroupedByTraceName_PercentilesUseFilteredRows(t *testing.T) {
 	setupTestDB(t)
 	ctx := context.Background()

--- a/backend/app/repositories/telemetry/ai_trace_repository_test.go
+++ b/backend/app/repositories/telemetry/ai_trace_repository_test.go
@@ -543,3 +543,39 @@ func TestAiTraceRepository_FindGroupedByTraceName_PercentilesUseFilteredRows(t *
 		t.Errorf("P95 computed over unfiltered rows: got %v, want 200ms", stats[0].P95Duration)
 	}
 }
+
+// FindGroupedByTraceName sorts and paginates in Go on P50/P95, so percentiles
+// computed over the unfiltered population reorder the page as well as
+// misreporting it. These two traces rank one way on all rows and the other way
+// on root rows alone.
+func TestAiTraceRepository_FindGroupedByTraceName_RanksOnFilteredRows(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	projectId := uuid.New()
+	now := truncateMs(time.Now().UTC())
+
+	var traces []models.AiTrace
+	for range 4 {
+		// Slow as a root call, which is what "root" asks to see.
+		traces = append(traces, makeAiTraceWithRoot(projectId, "trace.slow-root", 500*time.Millisecond, 100, 0.01, now, true))
+		traces = append(traces, makeAiTraceWithRoot(projectId, "trace.slow-root", 50*time.Millisecond, 100, 0.01, now, false))
+		// Fast as a root call, slow only in the rows the filter drops.
+		traces = append(traces, makeAiTraceWithRoot(projectId, "trace.fast-root", 100*time.Millisecond, 100, 0.01, now, true))
+		traces = append(traces, makeAiTraceWithRoot(projectId, "trace.fast-root", 10*time.Second, 100, 0.01, now, false))
+	}
+
+	if err := AiTraceRepository.InsertAsync(ctx, traces); err != nil {
+		t.Fatalf("InsertAsync failed: %v", err)
+	}
+
+	stats, _, err := AiTraceRepository.FindGroupedByTraceName(ctx, projectId, now.Add(-time.Hour), now.Add(time.Hour), 1, 10, "p95_duration", "desc", "", "root")
+	if err != nil {
+		t.Fatalf("FindGroupedByTraceName failed: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 grouped stats, got %d", len(stats))
+	}
+	if stats[0].TraceName != "trace.slow-root" {
+		t.Errorf("page ordered on unfiltered percentiles: got %q first, want \"trace.slow-root\"", stats[0].TraceName)
+	}
+}

--- a/backend/app/repositories/telemetry/ai_trace_repository_test.go
+++ b/backend/app/repositories/telemetry/ai_trace_repository_test.go
@@ -507,3 +507,39 @@ func TestAiTraceRepository_ListModels(t *testing.T) {
 		t.Errorf("ListModels = %v, expected [claude-sonnet-5 gpt-4o]", names)
 	}
 }
+
+// Same invariant as the tasks and endpoints lists: percentiles must describe the
+// rows the filter selects, since the list is ordered and paginated on them.
+func TestAiTraceRepository_FindGroupedByTraceName_PercentilesUseFilteredRows(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	projectId := uuid.New()
+	now := truncateMs(time.Now().UTC())
+
+	var traces []models.AiTrace
+	for range 4 {
+		traces = append(traces, makeAiTraceWithRoot(projectId, "agent.plan", 200*time.Millisecond, 100, 0.01, now, true))
+		traces = append(traces, makeAiTraceWithRoot(projectId, "agent.plan", 30*time.Second, 100, 0.01, now, false))
+	}
+
+	if err := AiTraceRepository.InsertAsync(ctx, traces); err != nil {
+		t.Fatalf("InsertAsync failed: %v", err)
+	}
+
+	stats, _, err := AiTraceRepository.FindGroupedByTraceName(ctx, projectId, now.Add(-time.Hour), now.Add(time.Hour), 1, 10, "count", "desc", "", "root")
+	if err != nil {
+		t.Fatalf("FindGroupedByTraceName failed: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 grouped stat, got %d", len(stats))
+	}
+	if stats[0].Count != 4 {
+		t.Errorf("expected count 4 under rootFilter=root, got %d", stats[0].Count)
+	}
+	if stats[0].P50Duration != 200*time.Millisecond {
+		t.Errorf("P50 computed over unfiltered rows: got %v, want 200ms", stats[0].P50Duration)
+	}
+	if stats[0].P95Duration != 200*time.Millisecond {
+		t.Errorf("P95 computed over unfiltered rows: got %v, want 200ms", stats[0].P95Duration)
+	}
+}

--- a/backend/app/repositories/telemetry/endpoint_repository_test.go
+++ b/backend/app/repositories/telemetry/endpoint_repository_test.go
@@ -582,3 +582,41 @@ func TestEndpointRepository_FindGroupedByEndpoint_RootFilterPercentiles(t *testi
 		t.Errorf("p95 = %v, want the root-only 100ms; non-root durations leaked into the percentile", stats[0].P95Duration)
 	}
 }
+
+// The chart ranks the top 5 on percentiles and then plots only the filtered
+// rows, so ranking on the unfiltered population puts endpoints on the chart that
+// are not slow under the filter. These two rank one way on all rows and the
+// other way on root rows alone.
+func TestEndpointRepository_GetEndpointStackedChart_RanksOnFilteredRows(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	projectId := uuid.New()
+	now := truncateMs(time.Now().UTC())
+
+	var endpoints []models.Endpoint
+	for range 3 {
+		// Slow as a root request, which is what "root" asks to see.
+		slowRoot := makeEndpoint(projectId, "GET /slow-root", 500*time.Millisecond, 200, now)
+		slowRoot.IsRoot = true
+		// Fast as a root request, slow only in the rows the filter drops.
+		fastRoot := makeEndpoint(projectId, "GET /fast-root", 10*time.Millisecond, 200, now)
+		fastRoot.IsRoot = true
+		endpoints = append(endpoints, slowRoot, fastRoot,
+			makeEndpoint(projectId, "GET /fast-root", 5*time.Second, 200, now))
+	}
+
+	if err := EndpointRepository.InsertAsync(ctx, endpoints); err != nil {
+		t.Fatalf("InsertAsync failed: %v", err)
+	}
+
+	chart, err := EndpointRepository.GetEndpointStackedChart(ctx, projectId, now.Add(-time.Hour), now.Add(time.Hour), 5, "p95", "", "root", "")
+	if err != nil {
+		t.Fatalf("GetEndpointStackedChart failed: %v", err)
+	}
+	if len(chart.Endpoints) < 2 {
+		t.Fatalf("expected both endpoints in the chart, got %v", chart.Endpoints)
+	}
+	if chart.Endpoints[0] != "GET /slow-root" {
+		t.Errorf("top endpoint ranked on unfiltered rows: got %v, want 'GET /slow-root' first", chart.Endpoints)
+	}
+}

--- a/backend/app/repositories/telemetry/helpers_test.go
+++ b/backend/app/repositories/telemetry/helpers_test.go
@@ -67,7 +67,9 @@ func makeAiTrace(projectId uuid.UUID, traceName string, duration time.Duration, 
 		TraceName:    traceName,
 		ServerName:   "test-server",
 		AppVersion:   "1.0.0",
-		IsRoot:       true,
+		// Unlike makeTask/makeEndpoint, AI traces default to root -- callers that
+		// need a child span go through makeAiTraceWithRoot.
+		IsRoot: true,
 	}
 }
 

--- a/backend/app/repositories/telemetry/helpers_test.go
+++ b/backend/app/repositories/telemetry/helpers_test.go
@@ -44,6 +44,12 @@ func makeTask(projectId uuid.UUID, taskName string, duration time.Duration, reco
 	}
 }
 
+func makeTaskWithRoot(projectId uuid.UUID, taskName string, duration time.Duration, recordedAt time.Time, isRoot bool) models.Task {
+	t := makeTask(projectId, taskName, duration, recordedAt)
+	t.IsRoot = isRoot
+	return t
+}
+
 func makeAiTrace(projectId uuid.UUID, traceName string, duration time.Duration, totalTokens int64, totalCost float64, recordedAt time.Time) models.AiTrace {
 	return models.AiTrace{
 		Id:           uuid.New(),
@@ -63,6 +69,12 @@ func makeAiTrace(projectId uuid.UUID, traceName string, duration time.Duration, 
 		AppVersion:   "1.0.0",
 		IsRoot:       true,
 	}
+}
+
+func makeAiTraceWithRoot(projectId uuid.UUID, traceName string, duration time.Duration, totalTokens int64, totalCost float64, recordedAt time.Time, isRoot bool) models.AiTrace {
+	tr := makeAiTrace(projectId, traceName, duration, totalTokens, totalCost, recordedAt)
+	tr.IsRoot = isRoot
+	return tr
 }
 
 func makeException(projectId uuid.UUID, hash, stackTrace string, recordedAt time.Time) models.ExceptionStackTrace {

--- a/backend/app/repositories/telemetry/sqlite/ai_trace.repository.go
+++ b/backend/app/repositories/telemetry/sqlite/ai_trace.repository.go
@@ -231,15 +231,23 @@ func (r *aiTraceRepository) InsertAsync(ctx context.Context, lines []models.AiTr
 	return tx.Commit()
 }
 
+// aiTraceFilterClause is the single definition of what the AI-traces list filters
+// on, so the query that selects a trace_name and the query that reads its
+// durations cannot drift apart. Both go through it.
+func aiTraceFilterClause(params lit.P, search, rootFilter string) string {
+	clause := ""
+	if search != "" {
+		clause += " AND INSTR(LOWER(trace_name), LOWER(:search)) > 0"
+		params["search"] = search
+	}
+	clause += shared.RootFilterClause("is_root", rootFilter)
+	return clause
+}
+
 func (r *aiTraceRepository) FindGroupedByTraceName(ctx context.Context, projectId uuid.UUID, fromDate, toDate time.Time, page, pageSize int, orderBy, sortDirection, search, rootFilter string) ([]models.AiTraceStats, int64, error) {
 	params := lit.P{"project_id": projectId, "from": sqlitetypes.NewSQLiteTime(fromDate), "to": sqlitetypes.NewSQLiteTime(toDate)}
 
-	whereClause := "project_id = :project_id AND recorded_at >= :from AND recorded_at <= :to"
-	if search != "" {
-		whereClause += " AND INSTR(LOWER(trace_name), LOWER(:search)) > 0"
-		params["search"] = search
-	}
-	whereClause += shared.RootFilterClause("is_root", rootFilter)
+	whereClause := "project_id = :project_id AND recorded_at >= :from AND recorded_at <= :to" + aiTraceFilterClause(params, search, rootFilter)
 
 	countResult, err := lit.SelectSingleNamed[models.CountResult](db.TelemetryDB,
 		"SELECT COUNT(DISTINCT trace_name) AS count FROM ai_traces WHERE "+whereClause, params)
@@ -269,11 +277,14 @@ func (r *aiTraceRepository) FindGroupedByTraceName(ctx context.Context, projectI
 
 	var stats []models.AiTraceStats
 	for _, row := range rows {
-		// Compute percentiles from raw durations for this trace_name
+		// Percentiles come from the raw durations, under the same filter that
+		// selected this trace_name -- otherwise the list reports and sorts on a
+		// population the user filtered out.
 		durationParams := lit.P{"project_id": projectId, "from": sqlitetypes.NewSQLiteTime(fromDate), "to": sqlitetypes.NewSQLiteTime(toDate), "trace_name": row.TraceName}
 		durationRows, err := lit.SelectNamed[aiTraceDurationRow](db.TelemetryDB,
 			`SELECT CAST(duration AS REAL) AS duration FROM ai_traces
-			WHERE project_id = :project_id AND trace_name = :trace_name AND recorded_at >= :from AND recorded_at <= :to
+			WHERE project_id = :project_id AND trace_name = :trace_name AND recorded_at >= :from AND recorded_at <= :to`+
+				aiTraceFilterClause(durationParams, search, rootFilter)+`
 			ORDER BY duration ASC`, durationParams)
 		if err != nil {
 			return nil, 0, err

--- a/backend/app/repositories/telemetry/sqlite/ai_trace.repository.go
+++ b/backend/app/repositories/telemetry/sqlite/ai_trace.repository.go
@@ -231,9 +231,10 @@ func (r *aiTraceRepository) InsertAsync(ctx context.Context, lines []models.AiTr
 	return tx.Commit()
 }
 
-// aiTraceFilterClause is the single definition of what the AI-traces list filters
-// on, so the query that selects a trace_name and the query that reads its
-// durations cannot drift apart. Both go through it.
+// aiTraceFilterClause appends the AI-traces list's filter to a WHERE clause and
+// binds what it needs into params. Both the query that selects a trace_name and
+// the query that reads its durations go through it, so they cannot filter
+// differently.
 func aiTraceFilterClause(params lit.P, search, rootFilter string) string {
 	clause := ""
 	if search != "" {
@@ -277,14 +278,12 @@ func (r *aiTraceRepository) FindGroupedByTraceName(ctx context.Context, projectI
 
 	var stats []models.AiTraceStats
 	for _, row := range rows {
-		// Percentiles come from the raw durations, under the same filter that
-		// selected this trace_name -- otherwise the list reports and sorts on a
-		// population the user filtered out.
+		// Compute percentiles from raw durations for this trace_name
 		durationParams := lit.P{"project_id": projectId, "from": sqlitetypes.NewSQLiteTime(fromDate), "to": sqlitetypes.NewSQLiteTime(toDate), "trace_name": row.TraceName}
+		durationFilter := aiTraceFilterClause(durationParams, search, rootFilter)
 		durationRows, err := lit.SelectNamed[aiTraceDurationRow](db.TelemetryDB,
 			`SELECT CAST(duration AS REAL) AS duration FROM ai_traces
-			WHERE project_id = :project_id AND trace_name = :trace_name AND recorded_at >= :from AND recorded_at <= :to`+
-				aiTraceFilterClause(durationParams, search, rootFilter)+`
+			WHERE project_id = :project_id AND trace_name = :trace_name AND recorded_at >= :from AND recorded_at <= :to`+durationFilter+`
 			ORDER BY duration ASC`, durationParams)
 		if err != nil {
 			return nil, 0, err

--- a/backend/app/repositories/telemetry/sqlite/endpoint.repository.go
+++ b/backend/app/repositories/telemetry/sqlite/endpoint.repository.go
@@ -306,7 +306,7 @@ func (e *endpointRepository) FindGroupedByEndpoint(ctx context.Context, projectI
 			continue
 		}
 
-		durations, err := fetchSortedDurations(ctx, projectId, g.Endpoint, fromDate, toDate, rootFilter)
+		durations, err := fetchSortedDurations(ctx, projectId, g.Endpoint, fromDate, toDate, search, rootFilter, methodFilter)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -534,7 +534,7 @@ func (e *endpointRepository) FindWorstEndpoints(ctx context.Context, projectId u
 
 	var stats []models.EndpointStats
 	for _, g := range groups {
-		durations, err := fetchSortedDurations(ctx, projectId, g.Endpoint, start, end, "")
+		durations, err := fetchSortedDurations(ctx, projectId, g.Endpoint, start, end, "", "", "")
 		if err != nil {
 			return nil, err
 		}
@@ -616,7 +616,7 @@ func (e *endpointRepository) GetEndpointStats(ctx context.Context, projectId uui
 			stats.Apdex = row.SatisfiedTolerating / float64(row.Count)
 		}
 
-		durations, err := fetchSortedDurations(ctx, projectId, endpoint, start, end, "")
+		durations, err := fetchSortedDurations(ctx, projectId, endpoint, start, end, "", "", "")
 		if err != nil {
 			return nil, err
 		}
@@ -838,10 +838,17 @@ func (e *endpointRepository) UpsertSlowEndpoint(ctx context.Context, projectId u
 
 // --- helpers ---
 
-func fetchSortedDurations(ctx context.Context, projectId uuid.UUID, endpoint string, from, to time.Time, rootFilter string) ([]float64, error) {
+// fetchSortedDurations runs the same filter as the query that selected the
+// endpoint, via endpointFilterClause rather than picking out the one leg that
+// constrains rows today, so a row-level predicate added there cannot silently
+// leave the percentiles describing a different population.
+func fetchSortedDurations(ctx context.Context, projectId uuid.UUID, endpoint string, from, to time.Time, search, rootFilter, methodFilter string) ([]float64, error) {
+	params := lit.P{"project_id": projectId, "endpoint": endpoint, "from": sqlitetypes.NewSQLiteTime(from), "to": sqlitetypes.NewSQLiteTime(to)}
+	filterClause := endpointFilterClause(params, "", search, rootFilter, methodFilter)
+
 	results, err := lit.SelectNamed[endpointDurationRow](db.TelemetryDB,
-		"SELECT duration FROM endpoints WHERE project_id = :project_id AND endpoint = :endpoint AND recorded_at >= :from AND recorded_at <= :to AND is_stream = 0"+shared.RootFilterClause("is_root", rootFilter)+" ORDER BY duration ASC",
-		lit.P{"project_id": projectId, "endpoint": endpoint, "from": sqlitetypes.NewSQLiteTime(from), "to": sqlitetypes.NewSQLiteTime(to)})
+		"SELECT duration FROM endpoints WHERE project_id = :project_id AND endpoint = :endpoint AND recorded_at >= :from AND recorded_at <= :to AND is_stream = 0"+filterClause+" ORDER BY duration ASC",
+		params)
 	if err != nil {
 		return nil, err
 	}
@@ -923,7 +930,7 @@ func getTopEndpointsByMetric(ctx context.Context, projectId uuid.UUID, from, to 
 
 	var metrics []epMetric
 	for _, ep := range epRows {
-		durations, err := fetchSortedDurations(ctx, projectId, ep.Endpoint, from, to, rootFilter)
+		durations, err := fetchSortedDurations(ctx, projectId, ep.Endpoint, from, to, search, rootFilter, methodFilter)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/app/repositories/telemetry/sqlite/task.repository.go
+++ b/backend/app/repositories/telemetry/sqlite/task.repository.go
@@ -168,6 +168,19 @@ func (e *taskRepository) FindAll(ctx context.Context, projectId uuid.UUID, fromD
 	return tasks, count, nil
 }
 
+// taskFilterClause appends the task list's filter to a WHERE clause and binds
+// what it needs into params. Both the query that selects a task and the query
+// that reads its durations go through it, so they cannot filter differently.
+func taskFilterClause(params lit.P, search, rootFilter string) string {
+	clause := ""
+	if search != "" {
+		clause += " AND INSTR(LOWER(task_name), LOWER(:search)) > 0"
+		params["search"] = search
+	}
+	clause += shared.RootFilterClause("is_root", rootFilter)
+	return clause
+}
+
 func (e *taskRepository) FindGroupedByTaskName(ctx context.Context, projectId uuid.UUID, fromDate, toDate time.Time, page, pageSize int, orderBy string, sortDirection string, search string, rootFilter string) ([]models.TaskStats, int64, error) {
 	params := lit.P{"project_id": projectId, "from": sqlitetypes.NewSQLiteTime(fromDate), "to": sqlitetypes.NewSQLiteTime(toDate)}
 	whereClause := "project_id = :project_id AND recorded_at >= :from AND recorded_at <= :to" + taskFilterClause(params, search, rootFilter)
@@ -514,19 +527,6 @@ func (e *taskRepository) FindByDistributedTraceId(ctx context.Context, distribut
 		tasks = append(tasks, row.toModel())
 	}
 	return tasks, nil
-}
-
-// taskFilterClause appends the task list's filter to a WHERE clause and binds
-// what it needs into params. Both the query that selects a task and the query
-// that reads its durations go through it, so they cannot filter differently.
-func taskFilterClause(params lit.P, search, rootFilter string) string {
-	clause := ""
-	if search != "" {
-		clause += " AND INSTR(LOWER(task_name), LOWER(:search)) > 0"
-		params["search"] = search
-	}
-	clause += shared.RootFilterClause("is_root", rootFilter)
-	return clause
 }
 
 func fetchSortedTaskDurations(ctx context.Context, projectId uuid.UUID, taskName string, from, to time.Time, search, rootFilter string) ([]float64, error) {

--- a/backend/app/repositories/telemetry/sqlite/task.repository.go
+++ b/backend/app/repositories/telemetry/sqlite/task.repository.go
@@ -170,12 +170,7 @@ func (e *taskRepository) FindAll(ctx context.Context, projectId uuid.UUID, fromD
 
 func (e *taskRepository) FindGroupedByTaskName(ctx context.Context, projectId uuid.UUID, fromDate, toDate time.Time, page, pageSize int, orderBy string, sortDirection string, search string, rootFilter string) ([]models.TaskStats, int64, error) {
 	params := lit.P{"project_id": projectId, "from": sqlitetypes.NewSQLiteTime(fromDate), "to": sqlitetypes.NewSQLiteTime(toDate)}
-	whereClause := "project_id = :project_id AND recorded_at >= :from AND recorded_at <= :to"
-	if search != "" {
-		whereClause += " AND INSTR(LOWER(task_name), LOWER(:search)) > 0"
-		params["search"] = search
-	}
-	whereClause += shared.RootFilterClause("is_root", rootFilter)
+	whereClause := "project_id = :project_id AND recorded_at >= :from AND recorded_at <= :to" + taskFilterClause(params, search, rootFilter)
 
 	totalResult, err := lit.SelectSingleNamed[models.CountResult](db.TelemetryDB,
 		"SELECT COUNT(DISTINCT task_name) AS count FROM tasks WHERE "+whereClause,
@@ -198,9 +193,9 @@ func (e *taskRepository) FindGroupedByTaskName(ctx context.Context, projectId uu
 	offset := (page - 1) * pageSize
 
 	var baseQuery string
-	groupParams := lit.P{"project_id": projectId, "from": sqlitetypes.NewSQLiteTime(fromDate), "to": sqlitetypes.NewSQLiteTime(toDate)}
-	if search != "" {
-		groupParams["search"] = search
+	groupParams := lit.P{}
+	for k, v := range params {
+		groupParams[k] = v
 	}
 
 	groupedCols := `task_name, COUNT(*) as count, AVG(duration) as avg_duration, MAX(recorded_at) as last_seen,
@@ -230,7 +225,7 @@ func (e *taskRepository) FindGroupedByTaskName(ctx context.Context, projectId uu
 
 	var stats []models.TaskStats
 	for _, g := range groups {
-		durations, err := fetchSortedTaskDurations(ctx, projectId, g.TaskName, fromDate, toDate)
+		durations, err := fetchSortedTaskDurations(ctx, projectId, g.TaskName, fromDate, toDate, search, rootFilter)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -419,7 +414,7 @@ func (e *taskRepository) FindWorstTasks(ctx context.Context, projectId uuid.UUID
 
 	var stats []models.TaskStats
 	for _, g := range groups {
-		durations, err := fetchSortedTaskDurations(ctx, projectId, g.TaskName, start, end)
+		durations, err := fetchSortedTaskDurations(ctx, projectId, g.TaskName, start, end, "", "")
 		if err != nil {
 			return nil, err
 		}
@@ -465,7 +460,7 @@ func (e *taskRepository) GetTaskStats(ctx context.Context, projectId uuid.UUID, 
 		return &models.TaskDetailStats{}, nil
 	}
 
-	durations, err := fetchSortedTaskDurations(ctx, projectId, taskName, start, end)
+	durations, err := fetchSortedTaskDurations(ctx, projectId, taskName, start, end, "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -525,10 +520,29 @@ func (e *taskRepository) FindByDistributedTraceId(ctx context.Context, distribut
 	return tasks, nil
 }
 
-func fetchSortedTaskDurations(ctx context.Context, projectId uuid.UUID, taskName string, from, to time.Time) ([]float64, error) {
+// taskFilterClause is the single definition of what the task list filters on, so
+// the query that selects a task and the query that reads its durations cannot
+// drift apart. Both go through it.
+func taskFilterClause(params lit.P, search, rootFilter string) string {
+	clause := ""
+	if search != "" {
+		clause += " AND INSTR(LOWER(task_name), LOWER(:search)) > 0"
+		params["search"] = search
+	}
+	clause += shared.RootFilterClause("is_root", rootFilter)
+	return clause
+}
+
+// fetchSortedTaskDurations runs the same filter as the query that selected the
+// task: a percentile must describe exactly the rows that filter selects, or the
+// caller reports and sorts on a population the user filtered out.
+func fetchSortedTaskDurations(ctx context.Context, projectId uuid.UUID, taskName string, from, to time.Time, search, rootFilter string) ([]float64, error) {
+	params := lit.P{"project_id": projectId, "task_name": taskName, "from": sqlitetypes.NewSQLiteTime(from), "to": sqlitetypes.NewSQLiteTime(to)}
+	filterClause := taskFilterClause(params, search, rootFilter)
+
 	results, err := lit.SelectNamed[durationValueRow](db.TelemetryDB,
-		"SELECT duration FROM tasks WHERE project_id = :project_id AND task_name = :task_name AND recorded_at >= :from AND recorded_at <= :to ORDER BY duration ASC",
-		lit.P{"project_id": projectId, "task_name": taskName, "from": sqlitetypes.NewSQLiteTime(from), "to": sqlitetypes.NewSQLiteTime(to)})
+		"SELECT duration FROM tasks WHERE project_id = :project_id AND task_name = :task_name AND recorded_at >= :from AND recorded_at <= :to"+filterClause+" ORDER BY duration ASC",
+		params)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/app/repositories/telemetry/sqlite/task.repository.go
+++ b/backend/app/repositories/telemetry/sqlite/task.repository.go
@@ -193,10 +193,6 @@ func (e *taskRepository) FindGroupedByTaskName(ctx context.Context, projectId uu
 	offset := (page - 1) * pageSize
 
 	var baseQuery string
-	groupParams := lit.P{}
-	for k, v := range params {
-		groupParams[k] = v
-	}
 
 	groupedCols := `task_name, COUNT(*) as count, AVG(duration) as avg_duration, MAX(recorded_at) as last_seen,
 			MAX(is_root) as has_root, MAX(CASE WHEN is_root = 0 THEN 1 ELSE 0 END) as has_non_root`
@@ -214,11 +210,11 @@ func (e *taskRepository) FindGroupedByTaskName(ctx context.Context, projectId uu
 		baseQuery = fmt.Sprintf(`SELECT `+groupedCols+`
 			FROM tasks WHERE `+whereClause+`
 			GROUP BY task_name ORDER BY %s %s LIMIT :limit OFFSET :offset`, expr, sortDir)
-		groupParams["limit"] = pageSize
-		groupParams["offset"] = offset
+		params["limit"] = pageSize
+		params["offset"] = offset
 	}
 
-	groups, err := lit.SelectNamed[taskGroupRow](db.TelemetryDB, baseQuery, groupParams)
+	groups, err := lit.SelectNamed[taskGroupRow](db.TelemetryDB, baseQuery, params)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -520,9 +516,9 @@ func (e *taskRepository) FindByDistributedTraceId(ctx context.Context, distribut
 	return tasks, nil
 }
 
-// taskFilterClause is the single definition of what the task list filters on, so
-// the query that selects a task and the query that reads its durations cannot
-// drift apart. Both go through it.
+// taskFilterClause appends the task list's filter to a WHERE clause and binds
+// what it needs into params. Both the query that selects a task and the query
+// that reads its durations go through it, so they cannot filter differently.
 func taskFilterClause(params lit.P, search, rootFilter string) string {
 	clause := ""
 	if search != "" {
@@ -533,9 +529,6 @@ func taskFilterClause(params lit.P, search, rootFilter string) string {
 	return clause
 }
 
-// fetchSortedTaskDurations runs the same filter as the query that selected the
-// task: a percentile must describe exactly the rows that filter selects, or the
-// caller reports and sorts on a population the user filtered out.
 func fetchSortedTaskDurations(ctx context.Context, projectId uuid.UUID, taskName string, from, to time.Time, search, rootFilter string) ([]float64, error) {
 	params := lit.P{"project_id": projectId, "task_name": taskName, "from": sqlitetypes.NewSQLiteTime(from), "to": sqlitetypes.NewSQLiteTime(to)}
 	filterClause := taskFilterClause(params, search, rootFilter)

--- a/backend/app/repositories/telemetry/task_repository_test.go
+++ b/backend/app/repositories/telemetry/task_repository_test.go
@@ -441,3 +441,40 @@ func TestTaskRepository_GetTaskStats_EmptyWindow(t *testing.T) {
 		t.Errorf("expected count 0, got %d", stats.Count)
 	}
 }
+
+// The P50/P95 columns must describe the rows the active filter selects. The list
+// also sorts on them for orderBy=p50_duration/p95_duration/impact, so computing
+// them over the unfiltered population reorders the page as well as misreporting it.
+func TestTaskRepository_FindGroupedByTaskName_PercentilesUseFilteredRows(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	projectId := uuid.New()
+	now := truncateMs(time.Now().UTC())
+
+	var tasks []models.Task
+	for range 4 {
+		tasks = append(tasks, makeTaskWithRoot(projectId, "nightly.report", 100*time.Millisecond, now, true))
+		tasks = append(tasks, makeTaskWithRoot(projectId, "nightly.report", 10*time.Second, now, false))
+	}
+
+	if err := TaskRepository.InsertAsync(ctx, tasks); err != nil {
+		t.Fatalf("InsertAsync failed: %v", err)
+	}
+
+	stats, _, err := TaskRepository.FindGroupedByTaskName(ctx, projectId, now.Add(-time.Hour), now.Add(time.Hour), 1, 10, "count", "desc", "", "root")
+	if err != nil {
+		t.Fatalf("FindGroupedByTaskName failed: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 grouped stat, got %d", len(stats))
+	}
+	if stats[0].Count != 4 {
+		t.Errorf("expected count 4 under rootFilter=root, got %d", stats[0].Count)
+	}
+	if stats[0].P50Duration != 100*time.Millisecond {
+		t.Errorf("P50 computed over unfiltered rows: got %v, want 100ms", stats[0].P50Duration)
+	}
+	if stats[0].P95Duration != 100*time.Millisecond {
+		t.Errorf("P95 computed over unfiltered rows: got %v, want 100ms", stats[0].P95Duration)
+	}
+}

--- a/backend/app/repositories/telemetry/task_repository_test.go
+++ b/backend/app/repositories/telemetry/task_repository_test.go
@@ -442,9 +442,7 @@ func TestTaskRepository_GetTaskStats_EmptyWindow(t *testing.T) {
 	}
 }
 
-// The P50/P95 columns must describe the rows the active filter selects. The list
-// also sorts on them for orderBy=p50_duration/p95_duration/impact, so computing
-// them over the unfiltered population reorders the page as well as misreporting it.
+// The P50/P95 columns must describe the rows the active filter selects.
 func TestTaskRepository_FindGroupedByTaskName_PercentilesUseFilteredRows(t *testing.T) {
 	setupTestDB(t)
 	ctx := context.Background()
@@ -476,5 +474,41 @@ func TestTaskRepository_FindGroupedByTaskName_PercentilesUseFilteredRows(t *test
 	}
 	if stats[0].P95Duration != 100*time.Millisecond {
 		t.Errorf("P95 computed over unfiltered rows: got %v, want 100ms", stats[0].P95Duration)
+	}
+}
+
+// orderBy=p50_duration/p95_duration/impact takes the Go-sort path, so percentiles
+// computed over the unfiltered population reorder the page as well as
+// misreporting it. Here the two tasks rank one way on all rows and the other way
+// on root rows alone.
+func TestTaskRepository_FindGroupedByTaskName_RanksOnFilteredRows(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	projectId := uuid.New()
+	now := truncateMs(time.Now().UTC())
+
+	var tasks []models.Task
+	for range 4 {
+		// Slow as a root task, which is what "root" asks to see.
+		tasks = append(tasks, makeTaskWithRoot(projectId, "task.slow-root", 500*time.Millisecond, now, true))
+		tasks = append(tasks, makeTaskWithRoot(projectId, "task.slow-root", 50*time.Millisecond, now, false))
+		// Fast as a root task, slow only in the rows the filter drops.
+		tasks = append(tasks, makeTaskWithRoot(projectId, "task.fast-root", 100*time.Millisecond, now, true))
+		tasks = append(tasks, makeTaskWithRoot(projectId, "task.fast-root", 10*time.Second, now, false))
+	}
+
+	if err := TaskRepository.InsertAsync(ctx, tasks); err != nil {
+		t.Fatalf("InsertAsync failed: %v", err)
+	}
+
+	stats, _, err := TaskRepository.FindGroupedByTaskName(ctx, projectId, now.Add(-time.Hour), now.Add(time.Hour), 1, 10, "p95_duration", "desc", "", "root")
+	if err != nil {
+		t.Fatalf("FindGroupedByTaskName failed: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 grouped stats, got %d", len(stats))
+	}
+	if stats[0].TaskName != "task.slow-root" {
+		t.Errorf("page ordered on unfiltered percentiles: got %q first, want \"task.slow-root\"", stats[0].TaskName)
 	}
 }


### PR DESCRIPTION
Closes #313. Rebased onto current `main` (which now carries `95a65d24`), and absorbs what was left of #318 — that PR is closed.

## The bug

Three list views computed their percentiles from a **second query that carried no filter**, while the grouping query that selected the rows applied a search/root filter. The percentile therefore described a different population than the rows the user asked for.

**This is worse than a mislabelled column.** All three lists *sort and paginate* on those percentiles — tasks via the `needsGoSort` path for `orderBy=p50_duration|p95_duration|impact`, AI traces via `orderByMap` directly, endpoints via `sortEndpointStats` and the chart's top-5 ranking. So the page was ordered by the population the user had just filtered out. The `count` column was already correct, which is exactly why it stayed invisible.

SQLite-only: DuckDB and ClickHouse compute the percentiles inline in the filtered aggregate. So it was also a backend parity break — identical data, different numbers and different row order.

## What is fixed here vs already on `main`

`95a65d24` fixed the **endpoints** case while this work was in review, threading `rootFilter` into `fetchSortedDurations`. It did not touch tasks or AI traces.

| entity | state |
|---|---|
| tasks | **fixed here** — live bug |
| AI traces | **fixed here** — live bug |
| endpoints | fixed on `main`; this PR adds forward-compat + the missing test |

## The fix

Each file routes the selecting query and the duration query through **one clause builder** — `taskFilterClause` / `aiTraceFilterClause` / the existing `endpointFilterClause` — so the two cannot drift apart, and a predicate added there is picked up by both.

The endpoint change carries **no behaviour change**: with the endpoint pinned by `endpoint = :endpoint`, the `search` and `method` legs cannot alter the row set, so `rootFilter` is the only load-bearing one. It buys that a future row-level predicate reaches the percentile query automatically. Picking one leg out by hand is how the original split happened, and all three entities now read the same way — which is why it belongs here rather than in a PR of its own.

Also drops a second parameter map in `FindGroupedByTaskName`: lit's `ParseNamedQuery` ignores keys the query never references, and the count query consumes `params` before pagination is added, so one map serves both.

## Verification

Four regression tests. The three that cover a live bug **fail on the pre-fix code** with exactly these values:

```
--- FAIL: TestTaskRepository_FindGroupedByTaskName_PercentilesUseFilteredRows
    P50 computed over unfiltered rows: got 5.05s, want 100ms
    P95 computed over unfiltered rows: got 10s, want 100ms
--- FAIL: TestTaskRepository_FindGroupedByTaskName_RanksOnFilteredRows
    page ordered on unfiltered percentiles: got "task.fast-root" first, want "task.slow-root"
--- FAIL: TestAiTraceRepository_FindGroupedByTraceName_PercentilesUseFilteredRows
    P50 computed over unfiltered rows: got 15.1s, want 200ms
--- FAIL: TestAiTraceRepository_FindGroupedByTraceName_RanksOnFilteredRows
    page ordered on unfiltered percentiles: got "trace.fast-root" first, want "trace.slow-root"
```

The fifth — `TestEndpointRepository_GetEndpointStackedChart_RanksOnFilteredRows` — **passes on `main`**. `95a65d24` fixed that path but only tested the grouped list, so this guards the existing fix rather than reporting a live bug. Stating that so a green run is not mistaken for "reproduced and fixed."

All tests live in the untagged `telemetry` package, so they run against all three backends and pass on DuckDB and ClickHouse unchanged — that contrast is the parity assertion.

Also reproduced end-to-end, not just in tests. Two binaries on the same seeded SQLite database, populated over real OTLP ingest (root and non-root CONSUMER spans for tasks, `gen_ai.*` spans for AI traces), queried over HTTP:

| | `main` | this branch |
|---|---|---|
| tasks, `rootFilter=all` | `count=8 p50=5050ms p95=10000ms` | same |
| tasks, `rootFilter=root` | `count=4 p50=5050ms p95=10000ms` ❌ | `count=4 p50=100ms p95=100ms` ✅ |
| ai-traces, `rootFilter=root` | `count=4 p50=15100ms p95=30000ms` ❌ | `count=4 p50=200ms p95=200ms` ✅ |

Local: `go test -race -count=1 ./app/...`, the DuckDB-tagged suites, `go vet ./app/...`, `gofmt` — all clean.

## Follow-ups, not in scope

- `idx_endpoints_project_endpoint` is `(project_id, endpoint)` with no `recorded_at`, so per-group duration queries scan a group's whole retained history to answer a short window.
- The structural fix: SQLite splits the percentile query only because it has no percentile aggregate. One filtered query ordered by `(group, duration)` partitioned in Go — the shape `getStackedChartWithPercentiles` already uses — removes the drift *and* the per-group N+1. The tests here protect that refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)