### PR TITLE
refactor: give sortEndpointStats a strict comparator

### DIFF
--- a/backend/app/repositories/telemetry/duckdb/endpoint.repository.go
+++ b/backend/app/repositories/telemetry/duckdb/endpoint.repository.go
@@ -823,27 +823,29 @@ func sortEndpointStats(stats []models.EndpointStats, orderBy string, sortDirecti
 	desc := sortDirection != "asc"
 
 	sort.Slice(stats, func(i, j int) bool {
-		var less bool
+		// Descending is the ascending comparison with the operands swapped.
+		// Negating the ascending result instead would return true for both
+		// (i, j) and (j, i) whenever two rows tie, which is not the strict
+		// weak ordering sort.Slice documents a requirement for.
+		if desc {
+			i, j = j, i
+		}
 		switch orderBy {
 		case "count":
-			less = stats[i].Count < stats[j].Count
+			return stats[i].Count < stats[j].Count
 		case "p50_duration":
-			less = stats[i].P50Duration < stats[j].P50Duration
+			return stats[i].P50Duration < stats[j].P50Duration
 		case "p95_duration":
-			less = stats[i].P95Duration < stats[j].P95Duration
+			return stats[i].P95Duration < stats[j].P95Duration
 		case "p99_duration":
-			less = stats[i].P99Duration < stats[j].P99Duration
+			return stats[i].P99Duration < stats[j].P99Duration
 		case "avg_duration":
-			less = stats[i].AvgDuration < stats[j].AvgDuration
+			return stats[i].AvgDuration < stats[j].AvgDuration
 		case "last_seen":
-			less = stats[i].LastSeen.Before(stats[j].LastSeen)
+			return stats[i].LastSeen.Before(stats[j].LastSeen)
 		default:
-			less = stats[i].Impact < stats[j].Impact
+			return stats[i].Impact < stats[j].Impact
 		}
-		if desc {
-			return !less
-		}
-		return less
 	})
 }
 

--- a/backend/app/repositories/telemetry/sqlite/endpoint.repository.go
+++ b/backend/app/repositories/telemetry/sqlite/endpoint.repository.go
@@ -856,27 +856,29 @@ func sortEndpointStats(stats []models.EndpointStats, orderBy string, sortDirecti
 	desc := sortDirection != "asc"
 
 	sort.Slice(stats, func(i, j int) bool {
-		var less bool
+		// Descending is the ascending comparison with the operands swapped.
+		// Negating the ascending result instead would return true for both
+		// (i, j) and (j, i) whenever two rows tie, which is not the strict
+		// weak ordering sort.Slice documents a requirement for.
+		if desc {
+			i, j = j, i
+		}
 		switch orderBy {
 		case "count":
-			less = stats[i].Count < stats[j].Count
+			return stats[i].Count < stats[j].Count
 		case "p50_duration":
-			less = stats[i].P50Duration < stats[j].P50Duration
+			return stats[i].P50Duration < stats[j].P50Duration
 		case "p95_duration":
-			less = stats[i].P95Duration < stats[j].P95Duration
+			return stats[i].P95Duration < stats[j].P95Duration
 		case "p99_duration":
-			less = stats[i].P99Duration < stats[j].P99Duration
+			return stats[i].P99Duration < stats[j].P99Duration
 		case "avg_duration":
-			less = stats[i].AvgDuration < stats[j].AvgDuration
+			return stats[i].AvgDuration < stats[j].AvgDuration
 		case "last_seen":
-			less = stats[i].LastSeen.Before(stats[j].LastSeen)
+			return stats[i].LastSeen.Before(stats[j].LastSeen)
 		default:
-			less = stats[i].Impact < stats[j].Impact
+			return stats[i].Impact < stats[j].Impact
 		}
-		if desc {
-			return !less
-		}
-		return less
 	})
 }
 


### PR DESCRIPTION
Small hygiene change found while reviewing the percentile work in #319. **Not a bug fix — see the measurement below before spending review time on it.**

## What

`sortEndpointStats` built its descending order by negating the ascending comparison:

```go
if desc {
    return !less
}
return less
```

For two rows that tie on the sort key, `less` is false in both directions, so `!less` returns **true for both `(i, j)` and `(j, i)`**. That is not the strict weak ordering `sort.Slice` documents a requirement for, and the results are then formally unspecified.

Descending is now the same comparison with the operands swapped, which is strict in both directions:

```go
if desc {
    i, j = j, i
}
switch orderBy {
case "count":
    return stats[i].Count < stats[j].Count
...
```

Identical change in `sqlite/` and `duckdb/` — the two copies of this function were byte-identical before and after. ClickHouse sorts in SQL and is unaffected.

## Why this is hygiene and not a fix

I tried to make the old comparator actually misbehave and could not:

| | |
|---|---|
| trials | 2400 |
| slice sizes | 8 – 20,000 |
| distinct values | 1 – 100 (heavy ties) |
| input patterns | random, ascending-modulo, descending-modulo |
| **misordered results** | **0** |
| **elements lost or duplicated** | **0** |

Go's pdqsort tolerates the `>=` comparator in practice today. So nothing is broken, and no user-visible symptom is being fixed. What the change buys is not depending on tolerance that `sort.Slice` explicitly does not promise — a future Go release is free to change it.

I had initially described this as tied rows reordering between page loads. That was wrong, and the probe above is what corrected it.

## No test

None can distinguish the two versions: any behaviour a test could assert holds for the old comparator too, which is exactly what the probe measured. Adding one would be coverage-shaped code that pins nothing.

## Precedent

`sqlite/task.repository.go` already uses the strict form (`>` for desc, `<` for asc) in all four of its sort sites. This brings the two endpoint repositories in line with the pattern already in the package.

## Verification

`go test -race -count=1 ./app/...`, the DuckDB-tagged repository suite, `go vet ./app/...`, `gofmt` — all clean.

**Reasonable to close this if you'd rather not carry the churn.** It is 6 lines of behaviour-preserving change against a risk that is currently theoretical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)