### PR TITLE
ci: move every first-party action off the Node 20 runtime

### DIFF
--- a/.github/workflows/backend-vulncheck.yml
+++ b/.github/workflows/backend-vulncheck.yml
@@ -69,17 +69,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      # setup-go@v7 installs the `toolchain` version of go.mod directly and
-      # pins GOTOOLCHAIN=local, so the scan runs on the same release
-      # release-traceway.yml builds the runner with -- no toolchain download.
-      # (Under v5 it read the `go` line and GOTOOLCHAIN=auto fetched the
-      # toolchain on first use; same version scanned, one less download.)
-      # The Docker images are not covered by that: the official golang
-      # bases set GOTOOLCHAIN=local, so they build with whatever the floating
-      # golang:1.26-* tag ships, which is >= what is scanned here. One setup-go
-      # cache shared by the three rows is fine here, unlike backend.yml: with
-      # no -race and no test builds the module cache is what matters, and it
-      # is identical across rows.
+      # setup-go@v7 installs the `toolchain` version of go.mod directly, so the
+      # scan runs on the same release release-traceway.yml builds the runner
+      # with. The Docker images are not covered by that: their golang bases pin
+      # GOTOOLCHAIN=local, so they ignore the `toolchain` line and build with
+      # whatever the floating golang:1.26-* tag ships, which is >= what is
+      # scanned here. One setup-go cache shared by the three rows is fine here,
+      # unlike backend.yml: with no -race and no test builds the module cache
+      # is what matters, and it is identical across rows.
       - name: Setup Go
         uses: actions/setup-go@v7
         with:

--- a/.github/workflows/backend-vulncheck.yml
+++ b/.github/workflows/backend-vulncheck.yml
@@ -67,18 +67,21 @@ jobs:
         working-directory: backend
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      # setup-go@v5 reads the `go` line of go.mod; Go's own GOTOOLCHAIN=auto
-      # then downloads the `toolchain` version, so the scan runs on the same
-      # release release-traceway.yml builds the runner with. The Docker images are not covered by that: the official golang
+      # setup-go@v7 installs the `toolchain` version of go.mod directly and
+      # pins GOTOOLCHAIN=local, so the scan runs on the same release
+      # release-traceway.yml builds the runner with -- no toolchain download.
+      # (Under v5 it read the `go` line and GOTOOLCHAIN=auto fetched the
+      # toolchain on first use; same version scanned, one less download.)
+      # The Docker images are not covered by that: the official golang
       # bases set GOTOOLCHAIN=local, so they build with whatever the floating
       # golang:1.26-* tag ships, which is >= what is scanned here. One setup-go
       # cache shared by the three rows is fine here, unlike backend.yml: with
       # no -race and no test builds the module cache is what matters, and it
       # is identical across rows.
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -36,10 +36,10 @@ jobs:
         working-directory: backend
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
           # Cached per build-tag set below instead: setup-go keys only on
@@ -49,7 +49,7 @@ jobs:
           cache: false
 
       - name: Cache Go modules and build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build
@@ -116,16 +116,16 @@ jobs:
       CGO_ENABLED: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
           cache: false
 
       - name: Cache Go modules and build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build
@@ -204,16 +204,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
           cache: false
 
       - name: Cache Go modules and build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Go
+        id: setup-go
         uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
@@ -48,16 +49,20 @@ jobs:
           # leaving the duckdb job to re-fetch ~131MB of libduckdb every run.
           cache: false
 
+      # The Go version is part of the key because both cached trees depend on
+      # it: go-build entries are compiler-keyed, and a Go bump otherwise leaves
+      # the superseded toolchain module sitting in ~/go/pkg/mod, which the
+      # run_id rotation below then copies forward on every run.
       - name: Cache Go modules and build
         uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: go-${{ runner.os }}-sqlite-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+          key: go-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-sqlite-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
           restore-keys: |
-            go-${{ runner.os }}-sqlite-${{ hashFiles('backend/go.sum') }}-
-            go-${{ runner.os }}-sqlite-
+            go-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-sqlite-${{ hashFiles('backend/go.sum') }}-
+            go-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-sqlite-
 
       # CGO_ENABLED=0 mirrors Dockerfile.sqlite, so CI links what ships.
       - name: Build
@@ -119,6 +124,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Go
+        id: setup-go
         uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
@@ -130,10 +136,10 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: go-${{ runner.os }}-duckdb-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+          key: go-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-duckdb-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
           restore-keys: |
-            go-${{ runner.os }}-duckdb-${{ hashFiles('backend/go.sum') }}-
-            go-${{ runner.os }}-duckdb-
+            go-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-duckdb-${{ hashFiles('backend/go.sum') }}-
+            go-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-duckdb-
 
       # Load-bearing, not redundant with the tests below: the test scope covers
       # two package trees, so this is what compiles every other package under
@@ -207,6 +213,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Go
+        id: setup-go
         uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
@@ -218,10 +225,10 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: go-${{ runner.os }}-pgch-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+          key: go-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-pgch-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
           restore-keys: |
-            go-${{ runner.os }}-pgch-${{ hashFiles('backend/go.sum') }}-
-            go-${{ runner.os }}-pgch-
+            go-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-pgch-${{ hashFiles('backend/go.sum') }}-
+            go-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-pgch-
 
       # CGO_ENABLED=0 mirrors Dockerfile and Dockerfile.minimal.
       - name: Build

--- a/.github/workflows/benchmark-hardware.yml
+++ b/.github/workflows/benchmark-hardware.yml
@@ -132,7 +132,7 @@ jobs:
       CLICKHOUSE_DATABASE: ${{ secrets.BENCH_CH_DATABASE }}
       BENCH_CH_HTTPS_PORT: ${{ secrets.BENCH_CH_HTTPS_PORT }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install hcloud CLI
         run: |
@@ -149,7 +149,7 @@ jobs:
           printf '%s\n' "${{ secrets.BENCHMARK_SSH_PRIVATE_KEY }}" > "$key"
           echo "BENCHMARK_SSH_KEY=$key" >> "$GITHUB_ENV"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.25'
 
@@ -166,7 +166,7 @@ jobs:
           fi
           ./benchmarks/scripts/run-matrix-entry.sh "${{ matrix.tier }}" "${{ matrix.mode }}" "${{ matrix.signal }}" "${{ github.event.inputs.duration }}" benchmarks/_artifact "" "${async_arg}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: result-${{ matrix.tier }}-${{ matrix.mode }}-${{ matrix.signal }}${{ github.event.inputs.async_insert == 'true' && '-async' || '' }}
@@ -178,13 +178,13 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Need history so the bot commit doesn't trample anything.
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: /tmp/results-raw
 

--- a/.github/workflows/benchmark-metricsdb.yml
+++ b/.github/workflows/benchmark-metricsdb.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -98,7 +98,7 @@ jobs:
           cp scripts/remote-*.sh _artifact/
           LD_LIBRARY_PATH=_artifact _artifact/metricsdb-bench --version
           ls -la _artifact
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: metricsdb-bench
           path: benchmarks/metricsdb/_artifact/
@@ -152,9 +152,9 @@ jobs:
       ARTIFACT_DIR: ${{ github.workspace }}/benchmarks/metricsdb/_artifact
       OUT_DIR: ${{ github.workspace }}/benchmarks/metricsdb/_results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: metricsdb-bench
           path: benchmarks/metricsdb/_artifact/
@@ -183,7 +183,7 @@ jobs:
         timeout-minutes: 330
         run: ./benchmarks/metricsdb/scripts/entry.sh ${{ matrix.db }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: metricsdb-result-${{ github.event.inputs.tier }}-${{ matrix.db }}
@@ -203,9 +203,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: metricsdb-result-*
           merge-multiple: true
@@ -223,7 +223,7 @@ jobs:
           got=$(find "${results}" -maxdepth 1 -name '*.json' | wc -l | tr -d ' ')
           echo "cells with a result file: ${got}/${{ needs.setup.outputs.expected }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: metricsdb-summary
           path: |

--- a/.github/workflows/benchmark-processor.yml
+++ b/.github/workflows/benchmark-processor.yml
@@ -77,13 +77,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
       - name: Build oxc shim
@@ -127,7 +127,7 @@ jobs:
             cp config-honeycomb.yaml config-honeycomb-ios.yaml config-honeycomb-android.yaml artifacts/
             [ -f ../../testing/symbolication/node-app/dist/app.mjs ] && cp ../../testing/symbolication/node-app/dist/app.mjs ../../testing/symbolication/node-app/dist/app.mjs.map artifacts/ || true
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: bench-artifacts
           path: benchmarks/processor/artifacts/
@@ -158,8 +158,8 @@ jobs:
       matrix:
         impl: ${{ fromJson(needs.setup.outputs.impls) }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: bench-artifacts
           path: benchmarks/processor/artifacts/
@@ -193,7 +193,7 @@ jobs:
           hcloud server delete "bench-sut-${{ github.run_id }}-${{ matrix.impl }}" 2>/dev/null || true
           hcloud server delete "bench-ldg-${{ github.run_id }}-${{ matrix.impl }}" 2>/dev/null || true
           hcloud ssh-key delete "bench-key-${{ github.run_id }}-${{ matrix.impl }}" 2>/dev/null || true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: results-${{ matrix.impl }}
@@ -204,8 +204,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           pattern: results-*
           merge-multiple: true
@@ -213,7 +213,7 @@ jobs:
       - name: Summarize
         working-directory: benchmarks/processor
         run: bash summarize.sh ./results | tee -a "$GITHUB_STEP_SUMMARY"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: summary
           path: benchmarks/processor/results/

--- a/.github/workflows/benchmark-symbolicator-cache.yml
+++ b/.github/workflows/benchmark-symbolicator-cache.yml
@@ -47,7 +47,7 @@ jobs:
     env:
       HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install hcloud CLI
         run: |
@@ -61,7 +61,7 @@ jobs:
           printf '%s\n' "${{ secrets.BENCHMARK_SSH_PRIVATE_KEY }}" > "$key"
           echo "BENCHMARK_SSH_KEY=$key" >> "$GITHUB_ENV"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
@@ -86,7 +86,7 @@ jobs:
             cat benchmarks/results-cachebench/summary.md >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: cachebench-${{ github.event.inputs.tier }}

--- a/.github/workflows/benchmark-symbolicator.yml
+++ b/.github/workflows/benchmark-symbolicator.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
@@ -32,7 +32,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache oxc shim build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -58,7 +58,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: symbolicator-bench
           path: symbolicator-bench.txt

--- a/.github/workflows/cli-contract.yml
+++ b/.github/workflows/cli-contract.yml
@@ -31,10 +31,10 @@ jobs:
         working-directory: cli/test/contract
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: cli/test/contract/go.mod
           cache-dependency-path: cli/test/contract/go.sum

--- a/.github/workflows/cli-lint.yml
+++ b/.github/workflows/cli-lint.yml
@@ -46,10 +46,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
@@ -73,10 +73,10 @@ jobs:
         working-directory: cli
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -29,10 +29,10 @@ jobs:
         working-directory: cli
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -36,7 +36,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
           fi
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "latest"
           cache: "npm"

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Determine version
         id: version

--- a/.github/workflows/release-traceway.yml
+++ b/.github/workflows/release-traceway.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           # frontend/package.json only declares a floor (>=22); keep the
           # release build on the same major the Dockerfiles use.
@@ -164,7 +164,7 @@ jobs:
             --notes "$NOTES"
 
       - name: Set up Go for runner binaries
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
 
@@ -198,7 +198,7 @@ jobs:
     needs: release
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release-website.yml
+++ b/.github/workflows/release-website.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "latest"
           cache: "npm"

--- a/.github/workflows/traceway-autofix.yml
+++ b/.github/workflows/traceway-autofix.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -34,7 +34,7 @@ jobs:
             -H "anthropic-version: 2023-06-01" -o /dev/null \
             || { echo "ANTHROPIC_API_KEY was rejected"; exit 1; }
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
@@ -129,7 +129,7 @@ jobs:
           git diff HEAD > "$RUNNER_TEMP/artifact/fix.patch" || true
           git status --porcelain > "$RUNNER_TEMP/artifact/changed-files.txt" || true
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: traceway-fix-issue-${{ github.event.issue.number }}

--- a/docs/pages/client/js-sdk/sourcemap-upload.mdx
+++ b/docs/pages/client/js-sdk/sourcemap-upload.mdx
@@ -87,8 +87,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
 


### PR DESCRIPTION
Part 1 of #326. Bumps the 63 `actions/*` pins across all 16 workflows. Part 2 (`ci/326-node24-third-party`) handles the six third-party actions on the release workflows and is stacked on this branch.

GitHub currently reports this as a run annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24

The forcing is the step before removal, and when that lands **every workflow breaks at once** — `release-traceway.yml` and `release-cli.yml` included. Losing the ability to cut a release is a bad way to find out.

| Action | | Uses |
|---|---|---|
| `actions/checkout` | v4 → **v7** | 25 |
| `actions/setup-go` | v5 → **v7** | 15 |
| `actions/upload-artifact` | v4 → **v7** | 10 |
| `actions/download-artifact` | v4 → **v8** | 5 |
| `actions/setup-node` | v4 → **v7** | 4 |
| `actions/cache` | v4 → **v6** | 4 |

`runs.using` was read at each source and target ref: all six were `node20`, all six are now `node24`.

## The three jumps with real behaviour changes

Not a `sed 's/@v4/@v7/'` — these skip 2–3 majors. Each was checked against how this repo actually calls it.

**`setup-go` v6 changed toolchain handling** ([#460](https://github.com/actions/setup-go/pull/460)), and this repo cares: CLAUDE.md documents keeping `go` and `toolchain` in `go.mod` distinct. v6 installs the **`toolchain`** version rather than the `go` line's, and sets `GOTOOLCHAIN=local` so Go does not download one itself.

Both modules pin `go 1.26.2` / `toolchain go1.26.6`, so the same compiler runs either way — v5 got there by downloading 1.26.6 on first use, v7 installs it directly. Same version, one less download.

`GOTOOLCHAIN=local` does mean a job that installs an *older* Go than a module's floor now errors instead of silently upgrading. One job installs an older Go: `benchmark-hardware.yml` (`go-version: '1.25'`). It only builds `benchmarks/loadgen`, which declares `go 1.25`; the backend there is built by `docker compose --build` on the Hetzner SUT, not by the runner's Go. So nothing regresses.

`backend-vulncheck.yml` documented the v5 mechanism in a comment — rewritten in this PR, since it would otherwise now be false.

**`setup-node` v5 auto-enables caching** when `package.json` has a `packageManager` field. No `package.json` in this repo has one, and three of the four call sites already set `cache: "npm"` explicitly.

**`download-artifact` v5 changed output paths** for single downloads **by ID**. Nothing here downloads by ID — every call site uses `name:`, or `pattern:` + `merge-multiple: true`, or downloads everything. v8 additionally errors rather than warns on a digest mismatch, which is the behaviour you'd want on a release artifact anyway.

`upload-artifact` v7's `archive: false` is opt-in with the default unchanged, and `cache` v5/v6 are runtime + ESM only — the key/restore semantics I'd expected to change didn't.

## Runner requirement

These releases require Actions Runner ≥ 2.327.1. Every job here is `ubuntu-latest` or `ubuntu-24.04` — all GitHub-hosted, no self-hosted runners — so that's already met.

## Validating

`backend.yml`, `backend-vulncheck.yml`, `cli.yml`, `cli-lint.yml` and `cli-contract.yml` all run on the `ci` label, which exercises `checkout`, `setup-go` and `cache` — including the `setup-go` toolchain change, which is the one worth actually watching. The benchmark workflows (`upload-artifact`/`download-artifact`) are `workflow_dispatch`-only and cost real money to run, so those two are argued from the changelogs and the call sites above rather than from a green run.

## Note for #315

`frontend.yml`, incoming via #315, adds `actions/checkout@v4` and `actions/setup-node@v4`. Worth bumping those to `@v7` there so it doesn't land already stale — this PR can't reach that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also: one docs recipe

`docs/pages/client/js-sdk/sourcemap-upload.mdx` ships a copy-paste GitHub Actions recipe pinning `checkout@v4` and `setup-node@v4` — a reader following it lands on the same annotation. Bumped to `@v7` in a separate commit.

Left alone deliberately: the `node-version: 20` on the next line of that snippet (a question about what Node the JS SDK supports, not about the action runtime), and `website/content/blog/auto-fix-loop.mdx`, which pins `upload-artifact@v4` in a published, dated post.


## From a cleanup pass over this diff

**`backend.yml`'s Go caches would have carried a dead toolchain forever.** Those three jobs set `cache: false` on setup-go and hand-roll `actions/cache` over `~/.cache/go-build` and `~/go/pkg/mod`, keyed on `go.sum` with a `${{ github.run_id }}` suffix — so every run saves a fresh entry and the restore-keys carry the previous tree forward.

Neither cached tree survives a Go version change. `go-build` entries are compiler-keyed, and until this branch `GOTOOLCHAIN=auto` materialised a ~250MB `golang.org/toolchain@...go1.26.6` module inside `GOMODCACHE`. setup-go v7 never writes that module again — but nothing deletes it either, and the module cache has no trimming, so the `run_id` rotation would have copied a dead toolchain forward on every run indefinitely.

Fixed by putting the resolved Go version in the key (`steps.setup-go.outputs.go-version`, with `id: setup-go` added to the three steps) rather than by a cleanup step. That fixes it for *every* future Go bump instead of this one — the cache generation now rotates whenever the compiler does. Costs one cold run per job, most of which was dead weight anyway.

**The vulncheck comment rewrite got tightened.** The first version named `GOTOOLCHAIN=local` for both setup-go and the golang Docker bases while asserting the two behave differently, which destroyed the contrast the comment exists to draw — the real difference is which Go gets installed first. The setup-go half no longer mentions the variable, and the Docker half now says explicitly that it ignores the `toolchain` line. The parenthetical recording v5's old behaviour is gone: no file pins `setup-go@v5` any more, and git blame is the right home for a version delta.

## Follow-ups filed

- **#330** — nothing in this repo detects action pin drift (no dependabot, no renovate, no pin check). Worth reading before closing #326: adopting Dependabot here is complicated by the label-gated CI, and half these pins sit on workflows no label reaches.
- **#331** — tracks unpinning Wrangler (see #329).
