### PR TITLE
perf: let per-hash and per-conversation telemetry reads seek instead of sorting

### DIFF
--- a/backend/app/migrations/sqlite_telemetry/0021_index_exceptions_hash_time.up.sql
+++ b/backend/app/migrations/sqlite_telemetry/0021_index_exceptions_hash_time.up.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_exceptions_project_hash;
+CREATE INDEX IF NOT EXISTS idx_exceptions_project_hash_recorded ON exception_stack_traces(project_id, exception_hash, recorded_at);

--- a/backend/app/migrations/sqlite_telemetry/0022_index_ai_traces_conversation_time.up.sql
+++ b/backend/app/migrations/sqlite_telemetry/0022_index_ai_traces_conversation_time.up.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_ai_traces_project_conversation;
+CREATE INDEX IF NOT EXISTS idx_ai_traces_project_conversation_recorded ON ai_traces(project_id, conversation_id, recorded_at);

--- a/backend/app/migrations/telemetry_group_index_test.go
+++ b/backend/app/migrations/telemetry_group_index_test.go
@@ -10,15 +10,12 @@ import (
 )
 
 // Every per-group telemetry read pairs a group column with the table's time
-// column: as a second filter on the grouped lists, as the ORDER BY on the
-// per-group detail reads. An index that stops at the group column leaves SQLite
-// choosing between two bad plans -- seek the time index and re-filter the group
-// per row, which is a whole-window scan per group on the lists and a whole-table
-// walk on a detail read whose group holds fewer rows than the LIMIT; or seek the
-// group and sort its entire history. Which one it picks flips on whether ANALYZE
-// has ever run, so both are reachable in production and neither shows up in a
-// functional test. Guard the covering indexes: a later migration must not narrow
-// or drop one unnoticed.
+// column -- as a second filter on the grouped lists, as the ORDER BY on the
+// per-group detail reads. An index that stops at the group column forces SQLite
+// to either re-filter the group across the whole window once per group, which is
+// quadratic in the number of groups, or seek the group and sort its entire
+// history. Both are unbounded and both are invisible to functional tests. Guard
+// the covering indexes so a later migration cannot narrow or drop one unnoticed.
 func TestTelemetryGroupIndexesCoverTimeColumn(t *testing.T) {
 	telemetryDB, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
@@ -52,7 +49,7 @@ func TestTelemetryGroupIndexesCoverTimeColumn(t *testing.T) {
 			t.Fatalf("%s: failed to inspect indexes: %v", tc.table, err)
 		}
 		if !covered {
-			t.Errorf("%s: no index leading with (project_id, %s, %s); per-group reads fall back to scanning the table or sorting the whole group", tc.table, tc.group, tc.timeCol)
+			t.Errorf("%s: no index leading with (project_id, %s, %s)", tc.table, tc.group, tc.timeCol)
 		}
 	}
 }

--- a/backend/app/migrations/telemetry_group_index_test.go
+++ b/backend/app/migrations/telemetry_group_index_test.go
@@ -35,6 +35,7 @@ func TestTelemetryGroupIndexesCoverTimeColumn(t *testing.T) {
 		{"endpoints", "endpoint", "recorded_at"},
 		{"tasks", "task_name", "recorded_at"},
 		{"ai_traces", "trace_name", "recorded_at"},
+		{"ai_traces", "conversation_id", "recorded_at"},
 		{"exception_stack_traces", "exception_hash", "recorded_at"},
 		{"check_results", "check_id", "recorded_at"},
 		{"log_records", "service_name", "timestamp"},

--- a/backend/app/migrations/telemetry_group_index_test.go
+++ b/backend/app/migrations/telemetry_group_index_test.go
@@ -9,13 +9,17 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-// The grouped-list reads for these three tables filter
-// (project_id, <group>, recorded_at). An index that stops at the group column
-// leaves SQLite to seek the (project_id, recorded_at) index and re-filter the
-// group column across the whole window once per group, which is quadratic in
-// the number of groups and invisible to functional tests. Guard the covering
-// indexes so a later migration cannot narrow or drop them unnoticed.
-func TestTelemetryGroupIndexesCoverRecordedAt(t *testing.T) {
+// Every per-group telemetry read pairs a group column with the table's time
+// column: as a second filter on the grouped lists, as the ORDER BY on the
+// per-group detail reads. An index that stops at the group column leaves SQLite
+// choosing between two bad plans -- seek the time index and re-filter the group
+// per row, which is a whole-window scan per group on the lists and a whole-table
+// walk on a detail read whose group holds fewer rows than the LIMIT; or seek the
+// group and sort its entire history. Which one it picks flips on whether ANALYZE
+// has ever run, so both are reachable in production and neither shows up in a
+// functional test. Guard the covering indexes: a later migration must not narrow
+// or drop one unnoticed.
+func TestTelemetryGroupIndexesCoverTimeColumn(t *testing.T) {
 	telemetryDB, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("failed to open in-memory sqlite: %v", err)
@@ -27,10 +31,14 @@ func TestTelemetryGroupIndexesCoverRecordedAt(t *testing.T) {
 		t.Fatalf("telemetry migrations failed: %v", err)
 	}
 
-	for _, tc := range []struct{ table, group string }{
-		{"endpoints", "endpoint"},
-		{"tasks", "task_name"},
-		{"ai_traces", "trace_name"},
+	for _, tc := range []struct{ table, group, timeCol string }{
+		{"endpoints", "endpoint", "recorded_at"},
+		{"tasks", "task_name", "recorded_at"},
+		{"ai_traces", "trace_name", "recorded_at"},
+		{"exception_stack_traces", "exception_hash", "recorded_at"},
+		{"check_results", "check_id", "recorded_at"},
+		{"log_records", "service_name", "timestamp"},
+		{"metric_points", "name", "recorded_at"},
 	} {
 		var covered bool
 		if err := telemetryDB.QueryRow(`
@@ -38,12 +46,12 @@ func TestTelemetryGroupIndexesCoverRecordedAt(t *testing.T) {
 				SELECT 1 FROM pragma_index_list(?1) AS il
 				WHERE (SELECT name FROM pragma_index_info(il.name) WHERE seqno = 0) = 'project_id'
 				  AND (SELECT name FROM pragma_index_info(il.name) WHERE seqno = 1) = ?2
-				  AND (SELECT name FROM pragma_index_info(il.name) WHERE seqno = 2) = 'recorded_at'
-			)`, tc.table, tc.group).Scan(&covered); err != nil {
+				  AND (SELECT name FROM pragma_index_info(il.name) WHERE seqno = 2) = ?3
+			)`, tc.table, tc.group, tc.timeCol).Scan(&covered); err != nil {
 			t.Fatalf("%s: failed to inspect indexes: %v", tc.table, err)
 		}
 		if !covered {
-			t.Errorf("%s: no index leading with (project_id, %s, recorded_at); per-group queries will scan the whole window once per group", tc.table, tc.group)
+			t.Errorf("%s: no index leading with (project_id, %s, %s); per-group reads fall back to scanning the table or sorting the whole group", tc.table, tc.group, tc.timeCol)
 		}
 	}
 }


### PR DESCRIPTION
Closes #335 and #336. #334 has merged, so this now targets `main` and carries two commits — one index widening per table.

`idx_exceptions_project_hash` stopped at the hash column, so nothing covered `(project_id, exception_hash, recorded_at)`. This widens it. The old index stays a leading prefix, so every query that used it stays covered.

## The issue's diagnosis was wrong in both directions

#335 predicted the paginated per-hash read would sort the group's whole history, and asked to "confirm the `USE TEMP B-TREE FOR ORDER BY` disappears". There is no temp B-tree in that plan to begin with — and more importantly, **the old index has a pathology in two different plans, and which one you get flips on whether `ANALYZE` has ever run.** Measuring only one stats state would have justified the change for the wrong reason and missed the worse half.

- **Without stats**, SQLite walks `idx_exceptions_project_recorded` in `recorded_at` order and re-filters the hash per row. Cost scales *inversely* with how noisy an issue is: an issue with fewer occurrences than the page holds can never satisfy the `LIMIT`, so it walks the entire project. That is the common case for a just-appeared issue — exactly when someone opens the page.
- **With stats**, it switches to the hash index and sorts. That fixes the two reads above and instead makes the **notification dispatch path** 2.35s per fired exception.

The widened index is the only shape that is fast in both states.

## Measurements

File-backed 2M-row, 500-hash, 30-day database (8.1GB, WAL), median of 3-5 runs. The multi-second figures are I/O-bound and move with page-cache warmth, so they are given as ranges across runs; the sub-millisecond ones were stable.

| | old | old + ANALYZE | **new** | **new + ANALYZE** |
|---|---|---|---|---|
| issues list (24h) | 4.9-24.8s | 305ms | **361ms** | **340ms** |
| issue page, 5 occurrences | 16.4-33.7s | 63µs | **44µs** | **54µs** |
| issue page, 252k occurrences | 335-479µs | 268µs | **323µs** | **167µs** |
| notify: latest occurrence | 64µs | 2.35s | **37µs** | **29µs** |
| notify: post-archive count | 15µs | 409ms | **23µs** | **23µs** |
| no-data poll: `MAX(recorded_at)` | 11µs | 28µs | **21µs** | **12µs** |
| `CountByHour` (control) | 40.5ms | 39.6ms | **40.2ms** | **43.2ms** |

`PRAGMA optimize` (`retention/sqlite.go:90`) is a no-op on a fresh connection and did not create `sqlite_stat1`, so the no-stats column is the likelier production state — but both are reachable, which is the point.

Two query sites outside the repository file turned out to be in scope and were not in the issue: the new-error evaluator's latest-occurrence and post-archive-count reads (`notifications/evaluator_event_sqlite.go`). Both are on the ingest-driven dispatch path.

The no-data poll's `MAX(recorded_at)` is the query with the most to lose — SQLite's min/max optimisation answers it in one seek only because `recorded_at` sits directly after `project_id` in `idx_exceptions_project_recorded`, which this does not touch. `EXPLAIN` confirms it keeps that index in all four configurations.

## Write cost

Below measurement noise. Three alternating runs: **19.8-22.6k rows/s** on the old index, **20.1-23.2k** on the widened one — overlapping ranges. This replaces an index rather than adding one, so it does not repeat the ~2x insert penalty the genuinely-new `tasks` index cost in #334. The entry is ~29% wider (a 30-char timestamp), about +60MB here. Building it took ~10s.

The `DROP`-then-`CREATE` ordering is safe because the migration version is recorded only after every statement succeeds (`migrations.go:73`) and boot panics on migration failure (`cmd/run.go:121`) — a killed index build re-runs cleanly rather than serving traffic without the index. That property is load-bearing and currently implicit.

## Guard test

`telemetry_group_index_test.go` grew a time-column field, so it now covers `check_results`, `log_records` (which uses `timestamp`, not `recorded_at`) and `metric_points` alongside the four `recorded_at` tables. Those three were already correctly indexed but unguarded — `metric_points` is the one with actual drift history (`0006` did this same drop-and-widen). Verified the test fails without `0021` and passes with it.

## Not done here

- **#337** — this and #334 together add four index builds to boot. Migrations log nothing and there is no `startupProbe` in the Helm chart, so a large-database upgrade can be killed mid-build by the liveness probe and crash-loop.
- No ClickHouse or DuckDB change. CH already has a `bloom_filter` skip index on `exception_hash` (`ch/0014`), which is the idiomatic equivalent — its `ORDER BY (project_id, recorded_at, exception_hash)` alone would not prune here, since the per-hash reads leave `recorded_at` unbounded. DuckDB is columnar and carries no secondary indexes.
- The main DB's vestigial `exception_stack_traces` (`sqlite/0002_telemetry_tables.up.sql`) is untouched. Every repository query site uses `db.TelemetryDB`, a physically separate file, so that copy never receives rows; #334 left its `endpoints` twin alone for the same reason.

