### PR TITLE
feat: report migration progress and let a slow one survive its supervisor

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -282,8 +282,9 @@ jobs:
       # setupTestDB skips unless TEST_CLICKHOUSE_SERVER is set, so these are
       # what opts the tagged suite in -- without them the job would report ok
       # while running nothing. app/chdb is included because batch_retry_test.go
-      # is `//go:build telemetry_ch` and would otherwise run in no job at all;
-      # it uses fakes and needs no live ClickHouse.
+      # is `//go:build telemetry_ch` and would otherwise run in no job at all,
+      # as is app/migrations for migrate_logger_test.go; both use fakes and need
+      # no live ClickHouse.
       #
       # -json is written to a file for the tally below and replayed through jq
       # so the log still reads like ordinary `go test` output. pipefail is set
@@ -302,7 +303,7 @@ jobs:
         run: |
           set -o pipefail
           go test -json -tags "transactional_pg telemetry_ch" -count=1 \
-            ./app/repositories/... ./app/chdb/... \
+            ./app/repositories/... ./app/chdb/... ./app/migrations/... \
             | tee "$RUNNER_TEMP/pgch-tests.jsonl" \
             | jq -j 'select(.Action == "output") | .Output'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ VOLUME ["/var/lib/clickhouse", "/var/lib/postgresql/data"]
 
 EXPOSE 80 8082
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=300s --retries=3 \
     CMD curl -f http://localhost/health || exit 1
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -106,7 +106,7 @@ ENV GIN_MODE=release \
 
 EXPOSE 80 8082
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=3s --start-period=300s --retries=3 \
     CMD wget -qO- http://localhost/health || exit 1
 
 ENTRYPOINT ["/usr/local/bin/traceway"]

--- a/Dockerfile.duckdb
+++ b/Dockerfile.duckdb
@@ -70,7 +70,7 @@ ENV GIN_MODE=release \
 
 EXPOSE 80 8082
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=3s --start-period=300s --retries=3 \
     CMD wget -qO- http://localhost/health || exit 1
 
 ENTRYPOINT ["/usr/local/bin/traceway"]

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -74,7 +74,7 @@ ENV GIN_MODE=release
 EXPOSE 80 8082
 
 # Health check using wget (alpine-native, no curl needed)
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=3s --start-period=300s --retries=3 \
     CMD wget -qO- http://localhost/health || exit 1
 
 # Run the binary directly (no systemd needed)

--- a/Dockerfile.sqlite
+++ b/Dockerfile.sqlite
@@ -72,7 +72,7 @@ ENV GIN_MODE=release \
 
 EXPOSE 80 8082
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=3s --start-period=300s --retries=3 \
     CMD wget -qO- http://localhost/health || exit 1
 
 ENTRYPOINT ["/usr/local/bin/traceway"]

--- a/backend/app/migrations/migrate_logger.go
+++ b/backend/app/migrations/migrate_logger.go
@@ -1,0 +1,35 @@
+//go:build telemetry_ch || transactional_pg
+
+package migrations
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tracewayapp/traceway/backend/app/config"
+)
+
+// migrateLogger is the backend name golang-migrate's output is labelled with.
+type migrateLogger string
+
+// migrate's buffering internals ride the same verbose stream as the pre-run
+// announcement, and only the announcement is worth a boot log line. Skipping by
+// prefix rather than keeping by one leaves migrate's error lines, and anything a
+// later version adds, to pass through.
+var migrateInternalPrefixes = []string{"Start buffering ", "Scheduled ", "Closing source and database"}
+
+func (l migrateLogger) Printf(format string, v ...any) {
+	message := fmt.Sprintf(format, v...)
+	for _, prefix := range migrateInternalPrefixes {
+		if strings.HasPrefix(message, prefix) {
+			return
+		}
+	}
+	config.Logf("migration %s: %s", string(l), message)
+}
+
+// Verbose is on because migrate names a migration before running it only on its
+// verbose stream. Without it a stall here is silent and the newest line names the
+// migration that already finished -- the opposite of what runMigrationsOn gives
+// the embedded backends.
+func (migrateLogger) Verbose() bool { return true }

--- a/backend/app/migrations/migrate_logger_test.go
+++ b/backend/app/migrations/migrate_logger_test.go
@@ -1,0 +1,48 @@
+//go:build telemetry_ch || transactional_pg
+
+package migrations
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The verbose stream migrateLogger subscribes to carries migrate's buffering
+// internals alongside the pre-run announcement, so Printf filters it. Filtering
+// by a skip list rather than a keep list is what leaves migrate's error lines --
+// which arrive through the same Printf -- visible, so pin that here: swapping the
+// two would silently swallow the reason a migration failed.
+func TestMigrateLoggerKeepsAnnouncementsAndErrors(t *testing.T) {
+	var buf bytes.Buffer
+	t.Cleanup(captureLog(&buf))
+
+	l := migrateLogger("postgres")
+	l.Printf("Start buffering %v\n", "34/u add_thing")
+	l.Printf("Scheduled %v\n", "34/u add_thing")
+	l.Printf("Read and execute %v\n", "34/u add_thing")
+	l.Printf("Finished %v (read %v, ran %v)\n", "34/u add_thing", "1ms", "9.4s")
+	l.Printf("Closing source and database\n")
+	l.Printf("error: %v", "connection refused")
+
+	got := buf.String()
+	for _, dropped := range []string{"Start buffering", "Scheduled", "Closing source"} {
+		if strings.Contains(got, dropped) {
+			t.Errorf("%q should have been filtered out, got:\n%s", dropped, got)
+		}
+	}
+	for _, kept := range []string{
+		"migration postgres: Read and execute 34/u add_thing",
+		"migration postgres: Finished 34/u add_thing (read 1ms, ran 9.4s)",
+		"migration postgres: error: connection refused",
+	} {
+		if !strings.Contains(got, kept) {
+			t.Errorf("%q should have survived, got:\n%s", kept, got)
+		}
+	}
+	// migrate terminates its formats with a newline and log adds its own only
+	// when one is absent, which is why Printf does not trim.
+	if strings.Contains(got, "\n\n") {
+		t.Errorf("blank line in output: %q", got)
+	}
+}

--- a/backend/app/migrations/migrations.go
+++ b/backend/app/migrations/migrations.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
+
+	"github.com/tracewayapp/traceway/backend/app/config"
 )
 
 type ExtensionMigration struct {
@@ -59,6 +62,12 @@ func runMigrationsOn(target *sql.DB, fsys embed.FS, dir, trackingTable, createTr
 			return fmt.Errorf("failed to read migration file %s: %w", file, err)
 		}
 
+		// Migrations finish before the HTTP server binds, and an index build on a
+		// large telemetry database emits nothing of its own for tens of seconds, so
+		// a boot that is still working looks exactly like one that has hung.
+		config.Logf("migration %s/%s: applying", dir, version)
+		started := time.Now()
+
 		statements := splitStatements(string(content))
 		for _, stmt := range statements {
 			stmt = strings.TrimSpace(stmt)
@@ -73,6 +82,8 @@ func runMigrationsOn(target *sql.DB, fsys embed.FS, dir, trackingTable, createTr
 		if _, err := target.Exec(fmt.Sprintf("INSERT INTO %s (version) VALUES (?)", trackingTable), version); err != nil {
 			return fmt.Errorf("failed to record migration version %s: %w", version, err)
 		}
+
+		config.Logf("migration %s/%s: applied in %s", dir, version, time.Since(started).Round(time.Millisecond))
 	}
 
 	return nil

--- a/backend/app/migrations/migrations_log_test.go
+++ b/backend/app/migrations/migrations_log_test.go
@@ -1,0 +1,68 @@
+package migrations
+
+import (
+	"bytes"
+	"database/sql"
+	"log"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// captureLog redirects the standard logger into buf and returns the restore
+// func. Restoring matters beyond tidiness: log.SetOutput(nil) leaves the logger
+// with a nil writer, so the next line logged anywhere in the binary panics.
+func captureLog(buf *bytes.Buffer) func() {
+	out, flags := log.Writer(), log.Flags()
+	log.SetOutput(buf)
+	log.SetFlags(0)
+	return func() {
+		log.SetOutput(out)
+		log.SetFlags(flags)
+	}
+}
+
+// Two properties carry the whole point of the migration logging, and neither is
+// visible to a functional test: the announcement has to precede the work, since
+// naming a migration only once it finishes is the silence this replaced; and an
+// already-applied migration has to stay quiet, or every restart reprints the
+// full history.
+func TestRunMigrationsOnAnnouncesBeforeApplyingAndOnlyOnce(t *testing.T) {
+	var buf bytes.Buffer
+	t.Cleanup(captureLog(&buf))
+
+	target, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory sqlite: %v", err)
+	}
+	defer target.Close()
+	target.SetMaxOpenConns(1)
+
+	if err := runMigrationsOn(target, migrationsSqliteFS, "sqlite", "schema_migrations", sqliteTrackingDDL); err != nil {
+		t.Fatalf("migrations failed: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) < 2 || len(lines)%2 != 0 {
+		t.Fatalf("want paired announce/complete lines, got %d:\n%s", len(lines), buf.String())
+	}
+	for i := 0; i < len(lines); i += 2 {
+		announcement, completion := lines[i], lines[i+1]
+		version, ok := strings.CutSuffix(strings.TrimPrefix(announcement, "[tracewaybackend] migration "), ": applying")
+		if !ok {
+			t.Fatalf("line %d should announce a migration, got %q", i, announcement)
+		}
+		if !strings.Contains(completion, "migration "+version+": applied in ") {
+			t.Errorf("%q was announced but the next line is not its completion: %q", version, completion)
+		}
+	}
+
+	buf.Reset()
+	if err := runMigrationsOn(target, migrationsSqliteFS, "sqlite", "schema_migrations", sqliteTrackingDDL); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("re-running applied migrations logged %q, want silence", buf.String())
+	}
+}

--- a/backend/app/migrations/migrations_telemetry_ch.go
+++ b/backend/app/migrations/migrations_telemetry_ch.go
@@ -41,6 +41,7 @@ func runMigrationsClickhouse(connStr string) error {
 	if err != nil {
 		return err
 	}
+	m.Log = migrateLogger("clickhouse")
 
 	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
 		return err

--- a/backend/app/migrations/migrations_transactional_pg.go
+++ b/backend/app/migrations/migrations_transactional_pg.go
@@ -41,6 +41,7 @@ func runMigrationsPostgres(connStr string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create migrate instance: %w", err)
 	}
+	m.Log = migrateLogger("postgres")
 
 	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
 		return fmt.Errorf("postgres migration failed: %w", err)
@@ -77,6 +78,7 @@ func runExtensionMigrations(db *sql.DB, ext ExtensionMigration) error {
 	if err != nil {
 		return fmt.Errorf("failed to create extension migrate instance: %w", err)
 	}
+	m.Log = migrateLogger("postgres " + tableName)
 
 	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
 		return fmt.Errorf("extension postgres migration failed: %w", err)

--- a/docker-compose.browser.yml
+++ b/docker-compose.browser.yml
@@ -58,7 +58,10 @@ services:
       test: ["CMD", "wget", "-qO-", "http://localhost/health"]
       interval: 30s
       timeout: 3s
-      start_period: 5s
+      # The server binds after migrations run, and a first boot on a large
+      # database can spend minutes building indexes. Docker ends the start
+      # period at the first success, so this only costs a slow first boot.
+      start_period: 300s
       retries: 3
 
 volumes:

--- a/docker-compose.duckdb.yml
+++ b/docker-compose.duckdb.yml
@@ -46,7 +46,10 @@ services:
       test: ["CMD", "wget", "-qO-", "http://localhost/health"]
       interval: 30s
       timeout: 3s
-      start_period: 5s
+      # The server binds after migrations run, and a first boot on a large
+      # database can spend minutes building indexes. Docker ends the start
+      # period at the first success, so this only costs a slow first boot.
+      start_period: 300s
       retries: 3
 
 volumes:

--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -36,7 +36,10 @@ services:
       test: ["CMD", "wget", "-qO-", "http://localhost/health"]
       interval: 30s
       timeout: 3s
-      start_period: 5s
+      # The server binds after migrations run, and a first boot on a large
+      # database can spend minutes building indexes. Docker ends the start
+      # period at the first success, so this only costs a slow first boot.
+      start_period: 300s
       retries: 3
 
 volumes:

--- a/helm/traceway/templates/deployment.yaml
+++ b/helm/traceway/templates/deployment.yaml
@@ -51,6 +51,15 @@ spec:
                 name: {{ include "traceway.fullname" . }}
             - secretRef:
                 name: {{ include "traceway.secretName" . }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /health

--- a/helm/traceway/values.yaml
+++ b/helm/traceway/values.yaml
@@ -38,6 +38,21 @@ ingress:
           pathType: Prefix
   tls: []
 
+# Startup probe. Kubernetes withholds liveness and readiness until it first
+# succeeds, so the liveness budget only starts once the process is serving. The
+# server binds after migrations run, and killing a pod mid-migration needs hand
+# repair either way: golang-migrate marks the version dirty before running it, so
+# ClickHouse/Postgres come back refusing to boot until someone runs force, and a
+# part-applied multi-statement file cannot be re-applied on SQLite/DuckDB.
+startupProbe:
+  enabled: true
+  # 100 x 5s. Deliberately under the Deployment's default progressDeadlineSeconds
+  # (600s), so a migration this probe tolerates is not simultaneously reported as
+  # a failed rollout -- which `helm --wait --atomic` or a GitOps self-heal would
+  # answer by deleting the pod mid-migration. Raising this past that ceiling means
+  # raising progressDeadlineSeconds and any deploy-tool timeout with it.
+  failureThreshold: 100
+
 resources: {}
 
 autoscaling:


### PR DESCRIPTION
Closes #337.

## The problem

`runMigrationsOn` ran every statement as a bare `Exec` — no transaction, no timing, no logging — and `migrations.Run` is called synchronously from `cmd/run.go` before the HTTP server binds. A boot that was still working looked exactly like one that had hung. #335 measured a single `CREATE INDEX` on `exception_stack_traces` at ~10s on a 2M-row / 8.1GB telemetry database.

Being killed part-way through does not repair itself, and I found the two storage families fail *differently* — the issue described only one of them:

| | on kill mid-migration |
|---|---|
| ClickHouse / Postgres | golang-migrate calls `SetVersion(target, **true**)` **before** `Run` (`migrate.go:738`), so the database comes back with a dirty `schema_migrations` and refuses to boot until someone runs `force` |
| SQLite / DuckDB | the version is recorded *after* the statements, and a file's statements are separately auto-committed, so a multi-statement file is left half applied |

The SQLite case is worse than "re-runs and is killed again". `sqlite_telemetry/0017` is five `ALTER TABLE ... ADD COLUMN` statements before a `CREATE INDEX`; those aren't idempotent, so a kill during the index build means the retry dies on `duplicate column name` — and so does every boot after it. `sqlite/0003`, `sqlite_telemetry/0009` and `duckdb_telemetry/0002` have the same shape.

**Making that atomic is deliberately not in this PR**, per #337's own note: it changes behaviour for every migration, not just the slow ones, and deserves its own look. What this does is stop supervisors killing the process in the first place, and say what is happening while it works.

## What changed

**Progress logging.** Each pending migration is announced before it runs and reported again with elapsed time. The announcement comes first so the newest line names whatever is *still running*, not what already finished. Already-applied migrations are skipped before the log call, so a steady-state restart is silent — only a boot that actually applies something costs lines.

**The golang-migrate paths too.** ClickHouse and Postgres don't go through `runMigrationsOn`, and that's the chart's default variant — fixing only the embedded path would have left the exact deployment shape this is about silent. `Verbose()` has to be on to get the same guarantee: migrate names a migration before running it *only* on its verbose stream. The buffering internals riding that stream are dropped by prefix — a skip list rather than a keep list, so migrate's own error lines still reach the log.

**A `startupProbe` in the chart.** Kubernetes withholds liveness and readiness until it first succeeds, so the ~70-100s liveness budget only starts once the process is serving. `100 x 5s` is deliberately under the Deployment's default `progressDeadlineSeconds` (600s): a migration the probe tolerates must not simultaneously be reported as a failed rollout, because `helm --wait --atomic` or a GitOps self-heal answers that by deleting the pod mid-migration — causing precisely what the probe prevents. Raising it past that ceiling means raising `progressDeadlineSeconds` too, which the values comment says.

**Docker had the same bug.** The four per-variant images and their compose files gave `/health` a 5s health-check start period, marking a container unhealthy ~95s in and breaking `--wait`, `depends_on: condition: service_healthy`, and orchestrators that restart on health state. Docker ends the start period at the first success, so raising it to 300s only ever costs a slow first boot.

**CI.** `migrate_logger_test.go` is build-tagged, and the tagged job only ran `./app/repositories/... ./app/chdb/...` — so the test would have run in no job at all. `./app/migrations/...` is added to that list, which is the hazard the workflow's own comment already documents for `app/chdb`.

## Validation

- `go vet` and `go test` clean on the default tags and on `transactional_pg telemetry_ch` (the combo CI uses)
- `gofmt` clean; default `go build ./...` clean
- `helm lint` passes; chart renders valid YAML across all three variants, with the probe present by default, removed under `startupProbe.enabled=false`, and honouring an overridden `failureThreshold`
- Verified empirically that a fresh SQLite install logs paired lines per migration and a second run is completely silent

Two tests are added: one pins the announce-before-work and silent-re-run properties on the embedded path, the other pins that the logger's skip list keeps migrate's error lines visible — swapping it for a keep list would silently swallow the reason a migration failed.

## Deliberately left out

- **Atomic migrations** (`#337` item 3) — the real fix for the half-applied-file case above, but it changes behaviour for every migration
- **Boot-phase logging generally** — `backfill.RunDashboards()` blocks on advisory lock 824737001 silently, and `cache.ProjectCache.Init` and `PostStartupHooks` are pre-bind and silent too. A `step("name", ...)` wrapper in `run.go` would generalize this; the startupProbe budget already covers them
- **systemd** — `notifySystemd()` sends `READY=1` only after migrations, so a `Type=notify` unit with the default `TimeoutStartSec=90` reproduces the same kill. `EXTEND_TIMEOUT_USEC` during migration is the equivalent fix
- **Making all three probes values-driven** — liveness and readiness stay hardcoded; this exposes only the budget knob a slow migration actually needs

Happy to file follow-up issues for any of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013b8tjKviUGfyVkrF7ccQkm

---
_Generated by [Claude Code](https://claude.ai/code/session_013b8tjKviUGfyVkrF7ccQkm)_