### PR TITLE
fix: match the endpoint method filter case-insensitively

### DIFF
--- a/backend/app/repositories/telemetry/clickhouse/endpoint.repository.go
+++ b/backend/app/repositories/telemetry/clickhouse/endpoint.repository.go
@@ -112,7 +112,10 @@ func endpointFilterClause(col, search, rootFilter, methodFilter string) (string,
 		clause += " AND " + col + "is_root = 0"
 	}
 	if methodFilter != "" {
-		clause += " AND startsWith(" + col + "endpoint, ?)"
+		// upper() not upperUTF8(): ASCII is the whole of RFC 9110's method token
+		// range, and the embedded backends' UPPER() is ASCII-only, so this keeps
+		// all three answering identically.
+		clause += " AND startsWith(upper(" + col + "endpoint), ?)"
 		args = append(args, shared.MethodPrefix(methodFilter))
 	}
 	return clause, args

--- a/backend/app/repositories/telemetry/endpoint_repository_test.go
+++ b/backend/app/repositories/telemetry/endpoint_repository_test.go
@@ -204,19 +204,56 @@ func TestEndpointRepository_FindGroupedByEndpoint_MethodFilter(t *testing.T) {
 		t.Fatalf("InsertAsync failed: %v", err)
 	}
 
+	// "GETAWAY /api/cars" must not match: the filter compares a whole
+	// space-terminated token, not a prefix of the endpoint string.
+	// "get /api/lowercase" must match. getHTTPEndpoint concatenates
+	// http.request.method verbatim, so lowercase rows genuinely exist, and the
+	// dropdown only ever offers the 7 canonical uppercase methods -- a
+	// case-sensitive comparison made those rows unreachable from the UI (#321).
 	stats, total, err := EndpointRepository.FindGroupedByEndpoint(ctx, projectId, now.Add(-time.Hour), now.Add(time.Hour), 1, 10, "count", "desc", "", "", "get")
 	if err != nil {
 		t.Fatalf("FindGroupedByEndpoint with method filter failed: %v", err)
 	}
 
-	if total != 1 {
-		t.Errorf("expected 1 matching endpoint, got %d", total)
+	if total != 2 {
+		t.Errorf("expected 2 matching endpoints, got %d", total)
 	}
-	if len(stats) != 1 {
-		t.Fatalf("expected 1 grouped stat, got %d", len(stats))
+	matched := make(map[string]bool, len(stats))
+	for _, s := range stats {
+		matched[s.Endpoint] = true
 	}
-	if stats[0].Endpoint != "GET /api/users" {
-		t.Errorf("expected 'GET /api/users', got %q", stats[0].Endpoint)
+	if len(stats) != 2 || !matched["GET /api/users"] || !matched["get /api/lowercase"] {
+		t.Fatalf("expected GET /api/users and get /api/lowercase, got %v", matched)
+	}
+}
+
+// The filter is applied by upper-casing the column, not the caller's argument,
+// so it holds however the request cased its method.
+func TestEndpointRepository_FindGroupedByEndpoint_MethodFilterCaseInsensitive(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	projectId := uuid.New()
+	now := truncateMs(time.Now().UTC())
+
+	endpoints := []models.Endpoint{
+		makeEndpoint(projectId, "GET /api/users", 100*time.Millisecond, 200, now),
+		makeEndpoint(projectId, "get /api/lowercase", 100*time.Millisecond, 200, now.Add(time.Minute)),
+		makeEndpoint(projectId, "Get /api/mixed", 100*time.Millisecond, 200, now.Add(2*time.Minute)),
+		makeEndpoint(projectId, "POST /api/users", 200*time.Millisecond, 201, now.Add(3*time.Minute)),
+	}
+
+	if err := EndpointRepository.InsertAsync(ctx, endpoints); err != nil {
+		t.Fatalf("InsertAsync failed: %v", err)
+	}
+
+	for _, method := range []string{"GET", "get", "GeT"} {
+		_, total, err := EndpointRepository.FindGroupedByEndpoint(ctx, projectId, now.Add(-time.Hour), now.Add(time.Hour), 1, 10, "count", "desc", "", "", method)
+		if err != nil {
+			t.Fatalf("methodFilter %q failed: %v", method, err)
+		}
+		if total != 3 {
+			t.Errorf("methodFilter %q: expected 3 matching endpoints, got %d", method, total)
+		}
 	}
 }
 

--- a/backend/app/repositories/telemetry/shared/sqlfilter.go
+++ b/backend/app/repositories/telemetry/shared/sqlfilter.go
@@ -19,16 +19,26 @@ func RootFilterClause(qualifiedCol, rootFilter string) string {
 	}
 }
 
+// MethodPrefix is the uppercase "GET " form every backend compares against.
+// The stored method is whatever the instrumented service reported --
+// getHTTPEndpoint concatenates http.request.method verbatim -- so the column
+// side is upper-cased at query time rather than the value being trusted.
 func MethodPrefix(method string) string {
 	return strings.ToUpper(method) + " "
 }
 
+// MethodFilterClause matches the method case-insensitively. SUBSTR rather than
+// LIKE because methodFilter reaches SQL as a value and LIKE would read % and _
+// in it as wildcards; UPPER around the column rather than a second bound
+// parameter so the comparison cannot depend on how the caller cased its input.
+// UPPER is ASCII-only in SQLite, which is exactly the range RFC 9110 allows a
+// method token.
 func MethodFilterClause(qualifiedCol, method string) (clause string, param string) {
 	if method == "" {
 		return "", ""
 	}
 	prefix := MethodPrefix(method)
-	return fmt.Sprintf(" AND SUBSTR(%s, 1, %d) = :method", qualifiedCol, len(prefix)), prefix
+	return fmt.Sprintf(" AND UPPER(SUBSTR(%s, 1, %d)) = :method", qualifiedCol, len(prefix)), prefix
 }
 
 // SortedKeys returns map keys in stable order so generated SQL and its


### PR DESCRIPTION
Closes #321. Implements option 2 from the issue discussion — *"I'd honestly do case insensitive querying"*.

## The problem

`getHTTPEndpoint` (`trace_converter.go`) concatenates `http.request.method` verbatim with no `ToUpper`, so `get /api/lowercase` rows genuinely exist. The dropdown only ever offers the 7 canonical uppercase methods, and `normalizeMethodFilter` upper-cases whatever it is given — so **no dropdown selection could ever reach such a row**, on any backend. They appeared in the unfiltered list, counted toward the total, and vanished the moment a method was picked.

## The fix

Upper-case the **column**, not the caller's argument, so the result can't depend on how the request cased its input:

| backend | before | after |
|---|---|---|
| SQLite / DuckDB | `SUBSTR(endpoint, 1, N) = :method` | `UPPER(SUBSTR(endpoint, 1, N)) = :method` |
| ClickHouse | `startsWith(endpoint, ?)` | `startsWith(upper(endpoint), ?)` |

Two deliberate choices:

- **`SUBSTR` stays, `LIKE` is still avoided.** `methodFilter` reaches SQL as a value, and `LIKE` would read a `%` or `_` in it as a wildcard. Keeping `SUBSTR` keeps that property while adding the case fold.
- **`upper()`, not `upperUTF8()`, on ClickHouse.** SQLite's `UPPER` is ASCII-only, and ASCII is the entire range RFC 9110 allows in a method token — so all three backends answer identically rather than diverging on non-ASCII input.

## This reverses a deliberate decision, not a bug

`c7a5dcae` shipped `TestEndpointRepository_FindGroupedByEndpoint_MethodFilter` asserting `get /api/lowercase` is **excluded**, as part of aligning the embedded backends onto ClickHouse's long-standing case sensitivity. That alignment was right; the reachability hole it left is what #321 is about. Worth flagging explicitly so the changed assertion doesn't read as an accident.

What stays asserted: **`GETAWAY /api/cars` must still not match `GET`.** The comparison is a whole space-terminated token, not a string prefix.

A second test covers the argument side — `GET`, `get` and `GeT` all return the same three rows.

## Verification

Unit tests pass on both embedded backends (default build and `-tags telemetry_duckdb`); the ClickHouse variant builds and vets under `-tags 'transactional_pg telemetry_ch'` (no CH server here to run it against).

Then against a running backend on a scratch SQLite DB, with `GET /api/users`, `get /api/lowercase`, `Get /api/mixed`, `GETAWAY /api/cars` and `POST /api/users` seeded:

```
POST /api/endpoints/grouped
  methodFilter="GET"   -> 3  ["GET /api/users","Get /api/mixed","get /api/lowercase"]
  methodFilter="get"   -> 3  ["GET /api/users","Get /api/mixed","get /api/lowercase"]
  methodFilter="GeT"   -> 3  ["GET /api/users","Get /api/mixed","get /api/lowercase"]
  methodFilter="POST"  -> 1  ["POST /api/users"]
  methodFilter=""      -> 5  (all, GETAWAY included)

POST /api/endpoints/chart
  methodFilter="GET"   -> ["Get /api/mixed","get /api/lowercase","GET /api/users"]
  methodFilter="get"   -> ["Get /api/mixed","get /api/lowercase","GET /api/users"]
```

## Left alone on purpose

Option 3 from the issue — `ToUpper` at ingest in `getHTTPEndpoint` — is **not** done here. It would not reach rows already stored (which is the actual complaint), and it merges two endpoint groups that are currently distinct, which is a data-shape change rather than a filter fix. Still open if you want canonical storage going forward; it composes with this rather than replacing it.

Also unchanged: the list still groups `get /x` and `GET /x` as two rows. Only the filter folds case; the grouping is what ingest decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
