### PR TITLE
fix: synchronize project cache across replicas

### DIFF
--- a/backend/app/cache/project_cache.go
+++ b/backend/app/cache/project_cache.go
@@ -19,6 +19,7 @@ type projectCache struct {
 	projectsById             map[uuid.UUID]*models.Project // key: id
 	projectsBySourceMapToken map[string]*models.Project    // key: source_map_token
 	mu                       sync.RWMutex
+	refreshMu                sync.Mutex
 	lastRefresh              time.Time
 }
 
@@ -29,10 +30,17 @@ var ProjectCache = &projectCache{
 }
 
 func (c *projectCache) Init(ctx context.Context) error {
+	if err := c.startListener(ctx); err != nil {
+		return err
+	}
+
 	return c.Refresh(ctx)
 }
 
 func (c *projectCache) Refresh(ctx context.Context) error {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+
 	projects, err := db.ExecuteTransaction(func(tx *sql.Tx) ([]*models.Project, error) {
 		return transactional.ProjectRepository.FindAll(tx)
 	})

--- a/backend/app/cache/project_cache_listener_other.go
+++ b/backend/app/cache/project_cache_listener_other.go
@@ -1,0 +1,9 @@
+//go:build !transactional_pg
+
+package cache
+
+import "context"
+
+func (c *projectCache) startListener(context.Context) error {
+	return nil
+}

--- a/backend/app/cache/project_cache_listener_pg.go
+++ b/backend/app/cache/project_cache_listener_pg.go
@@ -1,0 +1,40 @@
+//go:build transactional_pg
+
+package cache
+
+import (
+	"context"
+
+	"github.com/tracewayapp/traceway/backend/app/config"
+	"github.com/tracewayapp/traceway/backend/app/db"
+)
+
+func (c *projectCache) startListener(ctx context.Context) error {
+	listener := db.NewPostgresListener()
+	if err := listener.Listen(db.ProjectCacheNotificationChannel); err != nil {
+		listener.Close()
+		return err
+	}
+
+	go func() {
+		defer listener.Close()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case notification, ok := <-listener.Notify:
+				if !ok {
+					return
+				}
+				if notification == nil {
+					continue
+				}
+				if err := c.Refresh(ctx); err != nil {
+					config.Logf("project cache refresh failed after notification for project %s: %v", notification.Extra, err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}

--- a/backend/app/db/db.go
+++ b/backend/app/db/db.go
@@ -35,26 +35,7 @@ func IsDuckDBTelemetry() bool {
 }
 
 func initPostgres() error {
-	cfg := config.Config
-
-	host := cfg.PostgresHost
-	port := cfg.PostgresPort
-	database := cfg.PostgresDatabase
-	username := cfg.PostgresUsername
-	password := cfg.PostgresPassword
-	sslMode := cfg.PostgresSSLMode
-
-	if sslMode == "" {
-		sslMode = "disable"
-	}
-	if port == "" {
-		port = "5432"
-	}
-
-	connStr := fmt.Sprintf(
-		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
-		host, port, username, password, database, sslMode,
-	)
+	connStr := postgresConnectionString()
 
 	db, err := sql.Open("postgres", connStr)
 	if err != nil {
@@ -72,6 +53,24 @@ func initPostgres() error {
 	Driver = lit.PostgreSQL
 
 	return nil
+}
+
+func postgresConnectionString() string {
+	cfg := config.Config
+	port := cfg.PostgresPort
+	sslMode := cfg.PostgresSSLMode
+
+	if sslMode == "" {
+		sslMode = "disable"
+	}
+	if port == "" {
+		port = "5432"
+	}
+
+	return fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		cfg.PostgresHost, port, cfg.PostgresUsername, cfg.PostgresPassword, cfg.PostgresDatabase, sslMode,
+	)
 }
 
 func GetDB() *sql.DB {

--- a/backend/app/db/db_transactional_pg.go
+++ b/backend/app/db/db_transactional_pg.go
@@ -2,6 +2,31 @@
 
 package db
 
+import (
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+)
+
+const ProjectCacheNotificationChannel = "project_cache_changed"
+
 func initMainDB() error {
 	return initPostgres()
+}
+
+func NewPostgresListener() *pq.Listener {
+	return pq.NewListener(postgresConnectionString(), 10*time.Second, time.Minute, nil)
+}
+
+func NotifyProjectCacheChanged(tx *sql.Tx, projectId uuid.UUID) error {
+	return notifyProjectCacheChanged(tx, projectId)
+}
+
+func notifyProjectCacheChanged(execer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}, projectId uuid.UUID) error {
+	_, err := execer.Exec("SELECT pg_notify($1, $2)", ProjectCacheNotificationChannel, projectId.String())
+	return err
 }

--- a/backend/app/db/db_transactional_pg_test.go
+++ b/backend/app/db/db_transactional_pg_test.go
@@ -1,0 +1,43 @@
+//go:build transactional_pg
+
+package db
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+type recordingExecer struct {
+	query string
+	args  []any
+	err   error
+}
+
+func (e *recordingExecer) Exec(query string, args ...any) (sql.Result, error) {
+	e.query = query
+	e.args = args
+	return nil, e.err
+}
+
+func TestNotifyProjectCacheChangedIncludesProjectId(t *testing.T) {
+	projectId := uuid.New()
+	execer := &recordingExecer{}
+
+	if err := notifyProjectCacheChanged(execer, projectId); err != nil {
+		t.Fatalf("notify project cache changed: %v", err)
+	}
+	if execer.query != "SELECT pg_notify($1, $2)" {
+		t.Fatalf("query = %q", execer.query)
+	}
+	if len(execer.args) != 2 {
+		t.Fatalf("args = %#v", execer.args)
+	}
+	if execer.args[0] != ProjectCacheNotificationChannel {
+		t.Errorf("channel = %v", execer.args[0])
+	}
+	if execer.args[1] != projectId.String() {
+		t.Errorf("payload = %v", execer.args[1])
+	}
+}

--- a/backend/app/db/db_transactional_sqlite.go
+++ b/backend/app/db/db_transactional_sqlite.go
@@ -3,6 +3,9 @@
 package db
 
 import (
+	"database/sql"
+
+	"github.com/google/uuid"
 	"github.com/tracewayapp/lit/v2"
 	"github.com/tracewayapp/traceway/backend/app/config"
 )
@@ -25,5 +28,9 @@ func initMainDB() error {
 	Driver = lit.SQLite
 	config.Logf("SQLite database opened at %s", path)
 
+	return nil
+}
+
+func NotifyProjectCacheChanged(*sql.Tx, uuid.UUID) error {
 	return nil
 }

--- a/backend/app/repositories/transactional/pg/project.repository.go
+++ b/backend/app/repositories/transactional/pg/project.repository.go
@@ -161,6 +161,9 @@ func (p *projectRepository) Create(tx *sql.Tx, name string, framework string) (*
 	if err != nil {
 		return nil, err
 	}
+	if err := db.NotifyProjectCacheChanged(tx, project.Id); err != nil {
+		return nil, err
+	}
 
 	return project, nil
 }
@@ -186,6 +189,9 @@ func (p *projectRepository) CreateWithOrganization(tx *sql.Tx, name string, fram
 
 	err := lit.InsertExistingUuid(tx, project)
 	if err != nil {
+		return nil, err
+	}
+	if err := db.NotifyProjectCacheChanged(tx, project.Id); err != nil {
 		return nil, err
 	}
 
@@ -246,6 +252,9 @@ func (p *projectRepository) GenerateSourceMapToken(tx *sql.Tx, projectId uuid.UU
 	if err != nil {
 		return "", err
 	}
+	if err := db.NotifyProjectCacheChanged(tx, projectId); err != nil {
+		return "", err
+	}
 	return token, nil
 }
 
@@ -278,6 +287,9 @@ func (p *projectRepository) Update(tx *sql.Tx, id uuid.UUID, name string, framew
 	if err != nil {
 		return nil, err
 	}
+	if err := db.NotifyProjectCacheChanged(tx, id); err != nil {
+		return nil, err
+	}
 	return project, nil
 }
 
@@ -297,7 +309,10 @@ func (p *projectRepository) Delete(tx *sql.Tx, id uuid.UUID) error {
 			return fmt.Errorf("deleting %s: %w", table, err)
 		}
 	}
-	return lit.DeleteNamed(db.Driver, tx, "DELETE FROM projects WHERE id = :id", lit.P{"id": id})
+	if err := lit.DeleteNamed(db.Driver, tx, "DELETE FROM projects WHERE id = :id", lit.P{"id": id}); err != nil {
+		return err
+	}
+	return db.NotifyProjectCacheChanged(tx, id)
 }
 
 func (p *projectRepository) FindBySourceMapToken(tx *sql.Tx, token string) (*models.Project, error) {

--- a/backend/app/repositories/transactional/sqlite/project.repository.go
+++ b/backend/app/repositories/transactional/sqlite/project.repository.go
@@ -161,6 +161,9 @@ func (p *projectRepository) Create(tx *sql.Tx, name string, framework string) (*
 	if err != nil {
 		return nil, err
 	}
+	if err := db.NotifyProjectCacheChanged(tx, project.Id); err != nil {
+		return nil, err
+	}
 
 	return project, nil
 }
@@ -186,6 +189,9 @@ func (p *projectRepository) CreateWithOrganization(tx *sql.Tx, name string, fram
 
 	err := lit.InsertExistingUuid(tx, project)
 	if err != nil {
+		return nil, err
+	}
+	if err := db.NotifyProjectCacheChanged(tx, project.Id); err != nil {
 		return nil, err
 	}
 
@@ -246,6 +252,9 @@ func (p *projectRepository) GenerateSourceMapToken(tx *sql.Tx, projectId uuid.UU
 	if err != nil {
 		return "", err
 	}
+	if err := db.NotifyProjectCacheChanged(tx, projectId); err != nil {
+		return "", err
+	}
 	return token, nil
 }
 
@@ -278,6 +287,9 @@ func (p *projectRepository) Update(tx *sql.Tx, id uuid.UUID, name string, framew
 	if err != nil {
 		return nil, err
 	}
+	if err := db.NotifyProjectCacheChanged(tx, id); err != nil {
+		return nil, err
+	}
 	return project, nil
 }
 
@@ -297,7 +309,10 @@ func (p *projectRepository) Delete(tx *sql.Tx, id uuid.UUID) error {
 			return fmt.Errorf("deleting %s: %w", table, err)
 		}
 	}
-	return lit.DeleteNamed(db.Driver, tx, "DELETE FROM projects WHERE id = :id", lit.P{"id": id})
+	if err := lit.DeleteNamed(db.Driver, tx, "DELETE FROM projects WHERE id = :id", lit.P{"id": id}); err != nil {
+		return err
+	}
+	return db.NotifyProjectCacheChanged(tx, id)
 }
 
 func (p *projectRepository) FindBySourceMapToken(tx *sql.Tx, token string) (*models.Project, error) {


### PR DESCRIPTION
## Summary

- publish a PostgreSQL notification whenever a Project is created, updated, deleted, or has its source-map token rotated
- listen for those notifications on every PostgreSQL backend replica and atomically reload the complete in-memory Project cache
- keep SQLite deployments unchanged through a build-specific no-op notifier

## How it works

Project mutations call `pg_notify` inside the same transaction as the database write. PostgreSQL therefore publishes the event only after a successful commit. The payload contains the Project UUID, while listeners reload the complete snapshot so newly created tokens, removed tokens, rotated source-map tokens, and cached ingest settings all converge together.

Each PostgreSQL backend uses a dedicated `lib/pq` listener connection. The replica that made the change receives the same notification as the other replicas; its existing eager cache update remains valid, and the subsequent snapshot refresh is harmless. Full refreshes are serialized so an older overlapping database read cannot overwrite a newer snapshot.

This uses the PostgreSQL service already required by clustered deployments instead of introducing Redis solely for cache coordination. Single-instance SQLite deployments do not start a listener or gain another dependency.

Durable reconciliation after a listener disconnect is intentionally left for a follow-up. A periodic revision check can later cover notifications missed during a reconnect window.

Addresses #317.

## Verification

- `cd backend && go test ./...`
- `cd backend && go test -race ./app/cache`
- `cd backend && go test -tags 'transactional_pg telemetry_ch' ./app/db`
- `cd backend && go test -run '^$' -tags 'transactional_pg telemetry_ch' ./...`
