### PR TITLE
A member can't remove member with the same role

### DIFF
--- a/backend/app/controllers/member.controller.go
+++ b/backend/app/controllers/member.controller.go
@@ -1,13 +1,14 @@
 package controllers
 
 import (
+	"net/http"
+	"strconv"
+
 	"github.com/tracewayapp/traceway/backend/app/db"
 	"github.com/tracewayapp/traceway/backend/app/middleware"
 	"github.com/tracewayapp/traceway/backend/app/models"
 	"github.com/tracewayapp/traceway/backend/app/oncall"
 	"github.com/tracewayapp/traceway/backend/app/repositories/transactional"
-	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -84,6 +85,11 @@ func (c *memberController) RemoveMember(ctx *gin.Context) {
 		return
 	}
 
+	currentUserRole, err := transactional.OrganizationRepository.GetUserRole(tx, organizationId, currentUserId)
+	if err != nil {
+		ctx.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("Failed to get user role: %w", err))
+		return
+	}
 	targetRole, err := transactional.OrganizationRepository.GetUserRole(tx, organizationId, targetUserId)
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("Failed to get user role: %w", err))
@@ -96,6 +102,11 @@ func (c *memberController) RemoveMember(ctx *gin.Context) {
 
 	if targetRole == "owner" {
 		ctx.JSON(http.StatusForbidden, gin.H{"error": "Cannot remove the owner from the organization"})
+		return
+	}
+
+	if targetRole == currentUserRole {
+		ctx.JSON(http.StatusForbidden, gin.H{"error": "Cannot remove the user with the same role"})
 		return
 	}
 

--- a/frontend/src/routes/settings/users-tab.svelte
+++ b/frontend/src/routes/settings/users-tab.svelte
@@ -52,6 +52,7 @@
 	const invitations = $derived(organizationState.invitations.filter((i) => i.status === 'pending'));
 	const canInvite = $derived(organizationState.canInvite);
 	const isOwner = $derived(organizationState.isOwner);
+	const currentUserRole = $derived(organizationState.userRole);
 
 	const roleOptions = [
 		{ value: 'admin', label: 'Admin' },
@@ -165,7 +166,7 @@
 	}
 
 	function canRemoveMember(member: OrganizationMember): boolean {
-		return member.role !== 'owner';
+		return member.role !== 'owner' && member.role !== currentUserRole;
 	}
 
 	function getRoleBadgeVariant(role: string): 'default' | 'secondary' | 'destructive' | 'outline' {


### PR DESCRIPTION
Current behaviour:
- An admin can delete other admins on the platform.
- 
<img width="555" height="182" alt="Screenshot 2026-09-01 at 14 04 52" src="https://github.com/user-attachments/assets/2c80ab57-d457-48c3-ab46-572d5dc9528a" />

- Changes:
- A member can't delete other members if they have the same role. (Blocked on backend, trash icon is hidden in UI)

<img width="483" height="104" alt="Screenshot 2026-09-01 at 14 06 49" src="https://github.com/user-attachments/assets/8daed464-29ea-4bcc-9ba1-ac97ad158836" />
