### PR TITLE
ci: fix the auto-fix workflow_dispatch path and guard an empty project id

### DIFF
--- a/.github/actions/autofix-prepare/action.yml
+++ b/.github/actions/autofix-prepare/action.yml
@@ -102,6 +102,10 @@ runs:
         PROJECT_ID: ${{ inputs.project_id }}
       run: |
         set -euo pipefail
+        if [ -z "$PROJECT_ID" ]; then
+          echo "::error::project_id is empty. It is normally read from an Actions variable: check that TRACEWAY_PROJECT_ID exists as a variable and not only as a secret, because a job calling a reusable workflow cannot read the secrets context from its with: block."
+          exit 1
+        fi
         printf '%s' "$TOKEN" | traceway login --url "$URL" --token-stdin
         traceway projects use "$PROJECT_ID"
 

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -9,14 +9,19 @@
 # token; every write (push, PR, comment, archive) happens in the publish step
 # from validated inputs. That split is the security model, not the agent's
 # tool allowlist.
-name: Traceway auto-fix
+name: Traceway auto-fix (reusable)
 
 on:
   workflow_call:
     inputs:
       issue_number:
+        # Deliberately a string. A caller composing this from
+        # github.event.issue.number and a workflow_dispatch input yields a
+        # string on dispatch, and a number-typed input rejects that during
+        # workflow validation, before any job exists — so the run reports only
+        # "a workflow file issue" with no logs and no annotation.
         description: Number of the issue the Traceway GitHub channel opened
-        type: number
+        type: string
         required: true
       allowed_authors:
         description: Comma-separated GitHub logins allowed to trigger a run (the owner of the channel's token); every other issue author is refused

--- a/docs/pages/learn/auto-fix.mdx
+++ b/docs/pages/learn/auto-fix.mdx
@@ -32,7 +32,7 @@ The reusable workflow composes the three steps, with Claude Code as the tested a
 
 1. **Create two Traceway bot users** (or one; see [Credentials](#credentials)) and mint a [personal access token](/learn/cli-auth#personal-access-tokens) for each.
 2. **Add repository secrets**: `TRACEWAY_TOKEN` (read-only), `TRACEWAY_PUBLISH_TOKEN` (write, optional: without it the exception is never archived), `GH_PUSH_TOKEN` (a GitHub token that can push branches, open pull requests and comment; the built-in `github.token` cannot open a pull request that triggers other workflows), and `ANTHROPIC_API_KEY`.
-3. **Add a repository variable** `TRACEWAY_PROJECT_ID` with the project's id (`traceway projects list`).
+3. **Add a repository variable** `TRACEWAY_PROJECT_ID` with the project's id (`traceway projects list`). It has to be a variable rather than a secret, and the two fail differently: `with:` cannot reference the `secrets` context at all, so a caller that tries is rejected during workflow validation with no job and no logs, while an undefined `vars.TRACEWAY_PROJECT_ID` quietly resolves to an empty string and the prepare step stops with an error naming this variable.
 4. **Point the GitHub channel at the repository** with a label such as `traceway`, and create the caller workflow:
 
 ```yaml


### PR DESCRIPTION
Found by smoke-testing the loop that #356 shipped. That PR merged with zero CI checks (nothing gated watches `.github/` or `docs/`), and dispatching it on `main` fails immediately.

## The dispatch path never started

`gh workflow run traceway-autofix.yml -f issue_number=299` produces a run with **zero jobs** and the message "This run likely failed because of a workflow file issue" — no logs, no annotation, nothing in the API.

The reusable workflow declared `issue_number` as `type: number`, and the caller composes it as `${{ github.event.issue.number || inputs.issue_number }}`. On `workflow_dispatch` the first operand is null and the dispatch input arrives as a string, so the number-typed input is rejected during workflow validation, before any job exists.

The `issues: [labeled]` path was unaffected, because `github.event.issue.number` really is a number there. So the only thing that broke was the dispatch route that exists to validate the `claude-code-action` pin, which is why it went unnoticed.

`issue_number` is now `type: string`. Every consumer of it is a shell argument or a name fragment (`concurrency` group, artifact name, both composite actions), all quoted, none arithmetic.

## An empty project id failed obscurely

The prepare step ran `traceway projects use ""` when `project_id` resolved empty, which is exactly what happens in this repository today: `TRACEWAY_PROJECT_ID` exists as a **secret**, and both callers read `vars.TRACEWAY_PROJECT_ID`, which is undefined. It now stops with an annotation that names the variable.

The two ways to get this wrong fail differently, and the docs now say so: `with:` cannot reference the `secrets` context at all, so a caller that tries is rejected at validation with no job and no logs, whereas an undefined variable quietly becomes an empty string.

## Duplicate workflow name

Both files were `name: Traceway auto-fix`, so the Actions list showed two identical entries. The reusable one is now named for what it is.

## Verification

Bisected on a throwaway branch, since a startup failure exposes no logs. Each finding was reproduced and then re-run against the fix:

| Run | Result |
|---|---|
| `main` as merged | 0 jobs, workflow file issue |
| caller expressions replaced with literals | 1 job — isolates the problem to `issue_number` |
| `issue_number` reinstated as the only expression | 0 jobs — confirms it |
| `issue_number` retyped to `string` | 1 job, all steps reached |

On this branch a dispatch now creates the job, runs the checkout and the sparse checkout of the actions, and skips every step after the gate. A separate run with the credential preflight removed shows the prepare gate doing its job on a hashless issue:

```
##[warning]auto-fix skipped: the issue body carries no Traceway exception hash
  (a channel test notification, or not a Traceway issue)
```

`actionlint` and `shellcheck -S warning` are clean.

## Two things this PR cannot fix

Both are repository configuration, not code:

1. **`GH_PUSH_TOKEN` is expired.** The preflight fails with `gh: Bad credentials (HTTP 401)` and `remote: Invalid username or token`. The loop cannot push a branch or open a pull request until it is rotated. This predates the refactor.
2. **`TRACEWAY_PROJECT_ID` needs to exist as an Actions variable.** It is currently only a secret, and `vars.TRACEWAY_PROJECT_ID` resolves to empty (verified with a probe run).

Part of #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
