### PR TITLE
fix: return each node's spans from the distributed trace API

### DIFF
--- a/backend/app/controllers/distributed_trace.controller.go
+++ b/backend/app/controllers/distributed_trace.controller.go
@@ -126,41 +126,45 @@ func (d distributedTraceController) GetDistributedTrace(c *gin.Context) {
 	}
 
 	var nodes []DistributedTraceNode
+	var spanRefs []models.TraceRef
 
-	for _, ep := range endpoints {
-		node := DistributedTraceNode{
+	for i := range endpoints {
+		ep := &endpoints[i]
+		nodes = append(nodes, DistributedTraceNode{
 			ProjectId:   ep.ProjectId,
 			ProjectName: projectNameMap[ep.ProjectId],
 			TraceType:   "endpoint",
-			Endpoint:    &ep,
+			Endpoint:    ep,
 			Spans:       []models.Span{},
 			Exception:   exceptionByTraceId[ep.Id],
-		}
-		nodes = append(nodes, node)
+		})
+		spanRefs = append(spanRefs, models.TraceRef{ProjectId: ep.ProjectId, TraceId: ep.Id, RecordedAt: ep.RecordedAt})
 	}
 
-	for _, t := range tasks {
-		node := DistributedTraceNode{
+	for i := range tasks {
+		t := &tasks[i]
+		nodes = append(nodes, DistributedTraceNode{
 			ProjectId:   t.ProjectId,
 			ProjectName: projectNameMap[t.ProjectId],
 			TraceType:   "task",
-			Task:        &t,
+			Task:        t,
 			Spans:       []models.Span{},
 			Exception:   exceptionByTraceId[t.Id],
-		}
-		nodes = append(nodes, node)
+		})
+		spanRefs = append(spanRefs, models.TraceRef{ProjectId: t.ProjectId, TraceId: t.Id, RecordedAt: t.RecordedAt})
 	}
 
-	for _, a := range aiTraces {
-		node := DistributedTraceNode{
+	for i := range aiTraces {
+		a := &aiTraces[i]
+		nodes = append(nodes, DistributedTraceNode{
 			ProjectId:   a.ProjectId,
 			ProjectName: projectNameMap[a.ProjectId],
 			TraceType:   "ai_trace",
-			AiTrace:     &a,
+			AiTrace:     a,
 			Spans:       []models.Span{},
 			Exception:   exceptionByTraceId[a.Id],
-		}
-		nodes = append(nodes, node)
+		})
+		spanRefs = append(spanRefs, models.TraceRef{ProjectId: a.ProjectId, TraceId: a.Id, RecordedAt: a.RecordedAt})
 	}
 
 	for _, exc := range exceptions {
@@ -180,6 +184,15 @@ func (d distributedTraceController) GetDistributedTrace(c *gin.Context) {
 		})
 	}
 
+	// Each entity node owns the spans stored under its id as trace_id, the
+	// same ownership the detail pages read, loaded here in one bounded query.
+	spans, err := telemetry.SpanRepository.FindByTraceIds(ctx, spanRefs)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, traceway.NewStackTraceErrorf("failed to query spans: %w", err))
+		return
+	}
+	attachSpans(nodes, spans)
+
 	if nodes == nil {
 		nodes = []DistributedTraceNode{}
 	}
@@ -188,6 +201,37 @@ func (d distributedTraceController) GetDistributedTrace(c *gin.Context) {
 		DistributedTraceId: distributedTraceIdStr,
 		Nodes:              nodes,
 	})
+}
+
+// attachSpans hands every span to the node whose entity id and project it was
+// stored under. Exception-only nodes have no entity and keep their empty list.
+func attachSpans(nodes []DistributedTraceNode, spans []models.Span) {
+	byOwner := make(map[models.TraceRef][]models.Span)
+	for _, s := range spans {
+		key := models.TraceRef{ProjectId: s.ProjectId, TraceId: s.TraceId}
+		byOwner[key] = append(byOwner[key], s)
+	}
+	for i := range nodes {
+		owner, ok := nodes[i].spanOwner()
+		if !ok {
+			continue
+		}
+		if owned := byOwner[owner]; len(owned) > 0 {
+			nodes[i].Spans = owned
+		}
+	}
+}
+
+func (n DistributedTraceNode) spanOwner() (models.TraceRef, bool) {
+	switch {
+	case n.Endpoint != nil:
+		return models.TraceRef{ProjectId: n.ProjectId, TraceId: n.Endpoint.Id}, true
+	case n.Task != nil:
+		return models.TraceRef{ProjectId: n.ProjectId, TraceId: n.Task.Id}, true
+	case n.AiTrace != nil:
+		return models.TraceRef{ProjectId: n.ProjectId, TraceId: n.AiTrace.Id}, true
+	}
+	return models.TraceRef{}, false
 }
 
 var DistributedTraceController = distributedTraceController{}

--- a/backend/app/controllers/distributed_trace_test.go
+++ b/backend/app/controllers/distributed_trace_test.go
@@ -1,0 +1,124 @@
+//go:build !telemetry_ch && !transactional_pg && !telemetry_duckdb
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/tracewayapp/traceway/backend/app/db"
+	"github.com/tracewayapp/traceway/backend/app/models"
+	"github.com/tracewayapp/traceway/backend/app/repositories/telemetry"
+	"github.com/tracewayapp/traceway/backend/app/repositories/transactional"
+)
+
+func TestGetDistributedTraceAttachesSpansToOwningNodes(t *testing.T) {
+	setupSetupControllerDB(t)
+
+	tx, err := db.DB.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	userId, orgId := createSetupTestAccount(t, tx, "trace@example.com", "owner")
+	project, err := transactional.ProjectRepository.CreateWithOrganization(tx, "Trace", "opentelemetry", orgId)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	// The handler opens its own transaction on the single-connection main DB.
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	ctx := context.Background()
+	distributedTraceId := uuid.New()
+	at := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
+
+	endpoint := models.Endpoint{
+		Id: uuid.New(), ProjectId: project.Id, Endpoint: "GET /orders", Duration: 100 * time.Millisecond,
+		RecordedAt: at, StatusCode: 200, Attributes: map[string]string{}, DistributedTraceId: &distributedTraceId, IsRoot: true,
+	}
+	spanless := models.Endpoint{
+		Id: uuid.New(), ProjectId: project.Id, Endpoint: "GET /health", Duration: time.Millisecond,
+		RecordedAt: at, StatusCode: 200, Attributes: map[string]string{}, DistributedTraceId: &distributedTraceId,
+	}
+	if err := telemetry.EndpointRepository.InsertAsync(ctx, []models.Endpoint{endpoint, spanless}); err != nil {
+		t.Fatalf("insert endpoints: %v", err)
+	}
+	task := models.Task{
+		Id: uuid.New(), ProjectId: project.Id, TaskName: "send-receipt", Duration: 50 * time.Millisecond,
+		RecordedAt: at.Add(time.Second), Attributes: map[string]string{}, DistributedTraceId: &distributedTraceId,
+	}
+	if err := telemetry.TaskRepository.InsertAsync(ctx, []models.Task{task}); err != nil {
+		t.Fatalf("insert task: %v", err)
+	}
+
+	span := func(traceId uuid.UUID, name string, offset time.Duration) models.Span {
+		return models.Span{
+			Id: uuid.New(), TraceId: traceId, ProjectId: project.Id, Name: name,
+			StartTime: at.Add(offset), Duration: 5 * time.Millisecond, RecordedAt: at.Add(offset),
+		}
+	}
+	if err := telemetry.SpanRepository.InsertAsync(ctx, []models.Span{
+		span(endpoint.Id, "db.select orders", 20*time.Millisecond),
+		span(endpoint.Id, "publish receipt", 10*time.Millisecond),
+		span(task.Id, "smtp.send", time.Second+5*time.Millisecond),
+		// An orphan span keyed by the OTel trace id belongs to no node.
+		span(distributedTraceId, "orphan", 0),
+	}); err != nil {
+		t.Fatalf("insert spans: %v", err)
+	}
+
+	body := `{"recordedAt":"` + at.Format(time.RFC3339) + `"}`
+	c, recorder := newControllerTestContext(t, nil, userId, http.MethodPost, "/api/distributed-traces/"+distributedTraceId.String(), body)
+	c.Params = gin.Params{{Key: "distributedTraceId", Value: distributedTraceId.String()}}
+	DistributedTraceController.GetDistributedTrace(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var resp DistributedTraceResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Nodes) != 3 {
+		t.Fatalf("nodes = %d, want 3: %s", len(resp.Nodes), recorder.Body.String())
+	}
+
+	spanNames := func(node DistributedTraceNode) []string {
+		names := make([]string, 0, len(node.Spans))
+		for _, s := range node.Spans {
+			names = append(names, s.Name)
+		}
+		return names
+	}
+	for _, node := range resp.Nodes {
+		switch {
+		case node.Endpoint != nil && node.Endpoint.Id == endpoint.Id:
+			if got := spanNames(node); strings.Join(got, ",") != "publish receipt,db.select orders" {
+				t.Errorf("endpoint spans = %v, want both owned spans ordered by start time", got)
+			}
+		case node.Endpoint != nil && node.Endpoint.Id == spanless.Id:
+			if node.Spans == nil || len(node.Spans) != 0 {
+				t.Errorf("spanless endpoint spans = %v, want an empty list", node.Spans)
+			}
+		case node.Task != nil && node.Task.Id == task.Id:
+			if got := spanNames(node); strings.Join(got, ",") != "smtp.send" {
+				t.Errorf("task spans = %v, want the task's own span", got)
+			}
+		default:
+			t.Errorf("unexpected node %+v", node)
+		}
+	}
+	if !strings.Contains(recorder.Body.String(), `"spans":[]`) {
+		t.Errorf("a node without spans must serialize an empty array, got %s", recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), `"orphan"`) {
+		t.Errorf("the orphan span was attached to a node: %s", recorder.Body.String())
+	}
+}

--- a/backend/app/models/span.model.go
+++ b/backend/app/models/span.model.go
@@ -17,3 +17,12 @@ type Span struct {
 	ParentSpanId *uuid.UUID        `json:"parentSpanId,omitempty" ch:"parent_span_id"`
 	Attributes   map[string]string `json:"attributes,omitempty" ch:"attributes"`
 }
+
+// TraceRef names one entity's span tree. Spans are stored under their owning
+// endpoint, task or AI-trace id as trace_id, scoped to the project, and
+// RecordedAt anchors the lookup window.
+type TraceRef struct {
+	ProjectId  uuid.UUID
+	TraceId    uuid.UUID
+	RecordedAt time.Time
+}

--- a/backend/app/repositories/telemetry/clickhouse/span.repository.go
+++ b/backend/app/repositories/telemetry/clickhouse/span.repository.go
@@ -67,6 +67,39 @@ func (r *spanRepository) FindByTraceId(ctx context.Context, projectId, traceId u
 	}
 	defer rows.Close()
 
+	return scanSpans(rows)
+}
+
+// FindByTraceIds loads the spans of every referenced trace in one query, for
+// views that show several entities side by side. The lookup is bounded to the
+// trace window around the earliest and latest reference and follows the
+// (project_id, trace_id) ordering key.
+func (r *spanRepository) FindByTraceIds(ctx context.Context, refs []models.TraceRef) ([]models.Span, error) {
+	if len(refs) == 0 {
+		return []models.Span{}, nil
+	}
+	projectIds, traceIds := shared.TraceRefIds(refs)
+	from, to := shared.TraceRefsWindowBounds(refs)
+	query := `SELECT
+		id, trace_id, project_id, name, start_time, duration, recorded_at, parent_span_id, attributes
+	FROM spans
+	WHERE project_id IN (?) AND trace_id IN (?) AND recorded_at >= ? AND recorded_at <= ?
+	ORDER BY start_time ASC`
+
+	rows, err := chdb.Conn.Query(ctx, query, projectIds, traceIds, from, to)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	spans, err := scanSpans(rows)
+	if err != nil {
+		return nil, err
+	}
+	return shared.FilterSpansByTraceRefs(spans, refs), nil
+}
+
+func scanSpans(rows driver.Rows) ([]models.Span, error) {
 	var spans []models.Span
 	for rows.Next() {
 		var s models.Span
@@ -85,8 +118,7 @@ func (r *spanRepository) FindByTraceId(ctx context.Context, projectId, traceId u
 		}
 		spans = append(spans, s)
 	}
-
-	return spans, nil
+	return spans, rows.Err()
 }
 
 var SpanRepository = &spanRepository{}

--- a/backend/app/repositories/telemetry/duckdb/span.repository.go
+++ b/backend/app/repositories/telemetry/duckdb/span.repository.go
@@ -50,6 +50,14 @@ func (r *span) toModel() models.Span {
 	return s
 }
 
+func spansToModels(rows []*span) []models.Span {
+	spans := make([]models.Span, 0, len(rows))
+	for _, row := range rows {
+		spans = append(spans, row.toModel())
+	}
+	return spans
+}
+
 type spanRepository struct{}
 
 func (r *spanRepository) InsertAsync(ctx context.Context, spans []models.Span) error {
@@ -107,12 +115,31 @@ func (r *spanRepository) FindByTraceId(ctx context.Context, projectId, traceId u
 	if err != nil {
 		return nil, err
 	}
+	return spansToModels(rows), nil
+}
 
-	spans := make([]models.Span, 0, len(rows))
-	for _, row := range rows {
-		spans = append(spans, row.toModel())
+// FindByTraceIds loads the spans of every referenced trace in one query, for
+// views that show several entities side by side. The lookup is bounded to the
+// trace window around the earliest and latest reference.
+func (r *spanRepository) FindByTraceIds(ctx context.Context, refs []models.TraceRef) ([]models.Span, error) {
+	if len(refs) == 0 {
+		return []models.Span{}, nil
 	}
-	return spans, nil
+	projectIds, traceIds := shared.TraceRefIds(refs)
+	from, to := shared.TraceRefsWindowBounds(refs)
+	params := lit.P{"from": from.UTC(), "to": to.UTC()}
+	query := `SELECT id, trace_id, project_id, name, start_time, duration, recorded_at, parent_span_id, attributes
+		FROM spans
+		WHERE project_id IN (` + shared.NamedIdList("pid", projectIds, params) + `)
+		AND trace_id IN (` + shared.NamedIdList("tid", traceIds, params) + `)
+		AND recorded_at >= :from AND recorded_at <= :to
+		ORDER BY start_time ASC`
+
+	rows, err := lit.SelectNamed[span](db.TelemetryDB, query, params)
+	if err != nil {
+		return nil, err
+	}
+	return shared.FilterSpansByTraceRefs(spansToModels(rows), refs), nil
 }
 
 var SpanRepository = &spanRepository{}

--- a/backend/app/repositories/telemetry/shared/trace_refs.go
+++ b/backend/app/repositories/telemetry/shared/trace_refs.go
@@ -1,0 +1,84 @@
+package shared
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tracewayapp/lit/v2"
+	"github.com/tracewayapp/traceway/backend/app/models"
+)
+
+type traceKey struct {
+	projectId uuid.UUID
+	traceId   uuid.UUID
+}
+
+// TraceRefIds returns the distinct project ids and trace ids of refs in
+// first-seen order, for the two IN lists of a bulk span lookup.
+func TraceRefIds(refs []models.TraceRef) (projectIds, traceIds []uuid.UUID) {
+	seenProjects := make(map[uuid.UUID]struct{}, len(refs))
+	seenTraces := make(map[uuid.UUID]struct{}, len(refs))
+	for _, ref := range refs {
+		if _, ok := seenProjects[ref.ProjectId]; !ok {
+			seenProjects[ref.ProjectId] = struct{}{}
+			projectIds = append(projectIds, ref.ProjectId)
+		}
+		if _, ok := seenTraces[ref.TraceId]; !ok {
+			seenTraces[ref.TraceId] = struct{}{}
+			traceIds = append(traceIds, ref.TraceId)
+		}
+	}
+	return projectIds, traceIds
+}
+
+// TraceRefsWindowBounds widens the single-trace lookup window so it covers
+// every reference: from the earliest RecordedAt to the latest, each padded by
+// the usual trace window.
+func TraceRefsWindowBounds(refs []models.TraceRef) (time.Time, time.Time) {
+	if len(refs) == 0 {
+		return time.Time{}, time.Time{}
+	}
+	earliest, latest := refs[0].RecordedAt, refs[0].RecordedAt
+	for _, ref := range refs[1:] {
+		if ref.RecordedAt.Before(earliest) {
+			earliest = ref.RecordedAt
+		}
+		if ref.RecordedAt.After(latest) {
+			latest = ref.RecordedAt
+		}
+	}
+	from, _ := TraceWindowBounds(earliest)
+	_, to := TraceWindowBounds(latest)
+	return from, to
+}
+
+// FilterSpansByTraceRefs keeps the spans owned by a referenced (project,
+// trace) pair. The bulk query's two IN lists match their cross product, so a
+// trace id is only trusted inside the project that referenced it.
+func FilterSpansByTraceRefs(spans []models.Span, refs []models.TraceRef) []models.Span {
+	wanted := make(map[traceKey]struct{}, len(refs))
+	for _, ref := range refs {
+		wanted[traceKey{ref.ProjectId, ref.TraceId}] = struct{}{}
+	}
+	kept := make([]models.Span, 0, len(spans))
+	for _, s := range spans {
+		if _, ok := wanted[traceKey{s.ProjectId, s.TraceId}]; ok {
+			kept = append(kept, s)
+		}
+	}
+	return kept
+}
+
+// NamedIdList registers ids in params under prefix_N keys and returns the
+// matching ":prefix_0, :prefix_1, ..." placeholder list for an IN clause.
+func NamedIdList(prefix string, ids []uuid.UUID, params lit.P) string {
+	placeholders := make([]string, len(ids))
+	for i, id := range ids {
+		key := fmt.Sprintf("%s_%d", prefix, i)
+		placeholders[i] = ":" + key
+		params[key] = id
+	}
+	return strings.Join(placeholders, ", ")
+}

--- a/backend/app/repositories/telemetry/shared/trace_refs_test.go
+++ b/backend/app/repositories/telemetry/shared/trace_refs_test.go
@@ -1,0 +1,82 @@
+package shared
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tracewayapp/lit/v2"
+	"github.com/tracewayapp/traceway/backend/app/models"
+)
+
+func TestTraceRefIdsDedupesInFirstSeenOrder(t *testing.T) {
+	p1, p2 := uuid.New(), uuid.New()
+	t1, t2, t3 := uuid.New(), uuid.New(), uuid.New()
+	projectIds, traceIds := TraceRefIds([]models.TraceRef{
+		{ProjectId: p1, TraceId: t1},
+		{ProjectId: p2, TraceId: t2},
+		{ProjectId: p1, TraceId: t3},
+		{ProjectId: p2, TraceId: t2},
+	})
+	if len(projectIds) != 2 || projectIds[0] != p1 || projectIds[1] != p2 {
+		t.Fatalf("projectIds = %v, want [%s %s]", projectIds, p1, p2)
+	}
+	if len(traceIds) != 3 || traceIds[0] != t1 || traceIds[1] != t2 || traceIds[2] != t3 {
+		t.Fatalf("traceIds = %v, want [%s %s %s]", traceIds, t1, t2, t3)
+	}
+}
+
+func TestTraceRefsWindowBoundsCoversEveryRef(t *testing.T) {
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	from, to := TraceRefsWindowBounds([]models.TraceRef{
+		{RecordedAt: base.Add(3 * time.Hour)},
+		{RecordedAt: base},
+		{RecordedAt: base.Add(time.Hour)},
+	})
+	if want := base.Add(-traceLookupWindow); !from.Equal(want) {
+		t.Errorf("from = %v, want %v", from, want)
+	}
+	if want := base.Add(3*time.Hour + traceLookupWindow); !to.Equal(want) {
+		t.Errorf("to = %v, want %v", to, want)
+	}
+
+	from, to = TraceRefsWindowBounds(nil)
+	if !from.IsZero() || !to.IsZero() {
+		t.Errorf("empty refs gave a window %v..%v", from, to)
+	}
+}
+
+func TestFilterSpansByTraceRefsKeepsReferencedPairsOnly(t *testing.T) {
+	p1, p2 := uuid.New(), uuid.New()
+	t1, t2 := uuid.New(), uuid.New()
+	refs := []models.TraceRef{{ProjectId: p1, TraceId: t1}, {ProjectId: p2, TraceId: t2}}
+	kept := FilterSpansByTraceRefs([]models.Span{
+		{Name: "p1/t1", ProjectId: p1, TraceId: t1},
+		{Name: "p2/t1", ProjectId: p2, TraceId: t1},
+		{Name: "p1/t2", ProjectId: p1, TraceId: t2},
+		{Name: "p2/t2", ProjectId: p2, TraceId: t2},
+	}, refs)
+	if len(kept) != 2 || kept[0].Name != "p1/t1" || kept[1].Name != "p2/t2" {
+		t.Fatalf("kept = %+v, want the two referenced pairs", kept)
+	}
+	if kept = FilterSpansByTraceRefs(nil, refs); kept == nil || len(kept) != 0 {
+		t.Fatalf("no spans should give an empty, non-nil slice, got %#v", kept)
+	}
+}
+
+func TestNamedIdListRegistersEveryId(t *testing.T) {
+	ids := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()}
+	params := lit.P{}
+	if got := NamedIdList("pid", ids, params); got != ":pid_0, :pid_1, :pid_2" {
+		t.Fatalf("placeholders = %q", got)
+	}
+	for i, id := range ids {
+		key := "pid_" + string(rune('0'+i))
+		if params[key] != id {
+			t.Errorf("params[%s] = %v, want %s", key, params[key], id)
+		}
+	}
+	if got := NamedIdList("tid", nil, params); got != "" {
+		t.Fatalf("empty ids gave %q", got)
+	}
+}

--- a/backend/app/repositories/telemetry/span_repository_test.go
+++ b/backend/app/repositories/telemetry/span_repository_test.go
@@ -137,3 +137,74 @@ func TestSpanRepository_ProjectIsolation(t *testing.T) {
 		t.Errorf("expected span name 'span-p1', got %q", found[0].Name)
 	}
 }
+
+func TestSpanRepository_FindByTraceIds(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+	project1, project2 := uuid.New(), uuid.New()
+	traceA, traceB, traceC := uuid.New(), uuid.New(), uuid.New()
+	now := truncateMs(time.Now().UTC())
+	later := now.Add(2 * time.Hour)
+
+	spans := []models.Span{
+		makeSpan(project1, traceA, "a.first", now, 100*time.Millisecond),
+		makeSpan(project1, traceA, "a.second", now.Add(10*time.Millisecond), 50*time.Millisecond),
+		makeSpan(project2, traceB, "b.only", later, 20*time.Millisecond),
+		// Same trace id as traceA but stored under a project that did not
+		// reference it: the two IN lists alone would match it.
+		makeSpan(project2, traceA, "a.wrong-project", now, 10*time.Millisecond),
+		makeSpan(project1, traceC, "c.unreferenced", now, 10*time.Millisecond),
+		makeSpan(project1, traceA, "a.outside-window", now.Add(-48*time.Hour), 10*time.Millisecond),
+	}
+	if err := SpanRepository.InsertAsync(ctx, spans); err != nil {
+		t.Fatalf("InsertAsync failed: %v", err)
+	}
+
+	found, err := SpanRepository.FindByTraceIds(ctx, []models.TraceRef{
+		{ProjectId: project1, TraceId: traceA, RecordedAt: now},
+		{ProjectId: project2, TraceId: traceB, RecordedAt: later},
+	})
+	if err != nil {
+		t.Fatalf("FindByTraceIds failed: %v", err)
+	}
+
+	var names []string
+	for _, s := range found {
+		names = append(names, s.Name)
+	}
+	want := []string{"a.first", "a.second", "b.only"}
+	if len(names) != len(want) {
+		t.Fatalf("spans = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("spans = %v, want %v (ordered by start_time)", names, want)
+		}
+	}
+	if found[2].ProjectId != project2 || found[2].TraceId != traceB {
+		t.Errorf("b.only owner = %s/%s, want %s/%s", found[2].ProjectId, found[2].TraceId, project2, traceB)
+	}
+}
+
+func TestSpanRepository_FindByTraceIds_Empty(t *testing.T) {
+	setupTestDB(t)
+	ctx := context.Background()
+
+	found, err := SpanRepository.FindByTraceIds(ctx, nil)
+	if err != nil {
+		t.Fatalf("FindByTraceIds with no refs failed: %v", err)
+	}
+	if found == nil || len(found) != 0 {
+		t.Fatalf("no refs should give an empty, non-nil slice, got %#v", found)
+	}
+
+	found, err = SpanRepository.FindByTraceIds(ctx, []models.TraceRef{
+		{ProjectId: uuid.New(), TraceId: uuid.New(), RecordedAt: time.Now().UTC()},
+	})
+	if err != nil {
+		t.Fatalf("FindByTraceIds for an unknown trace failed: %v", err)
+	}
+	if found == nil || len(found) != 0 {
+		t.Fatalf("unknown trace should give an empty, non-nil slice, got %#v", found)
+	}
+}

--- a/backend/app/repositories/telemetry/sqlite/span.repository.go
+++ b/backend/app/repositories/telemetry/sqlite/span.repository.go
@@ -63,6 +63,14 @@ func (r *span) toModel() models.Span {
 	return s
 }
 
+func spansToModels(rows []*span) []models.Span {
+	spans := make([]models.Span, 0, len(rows))
+	for _, row := range rows {
+		spans = append(spans, row.toModel())
+	}
+	return spans
+}
+
 type spanRepository struct{}
 
 func (r *spanRepository) InsertAsync(ctx context.Context, spans []models.Span) error {
@@ -103,12 +111,32 @@ func (r *spanRepository) FindByTraceId(ctx context.Context, projectId, traceId u
 	if err != nil {
 		return nil, err
 	}
+	return spansToModels(rows), nil
+}
 
-	spans := make([]models.Span, 0, len(rows))
-	for _, row := range rows {
-		spans = append(spans, row.toModel())
+// FindByTraceIds loads the spans of every referenced trace in one query, for
+// views that show several entities side by side. The lookup is bounded to the
+// trace window around the earliest and latest reference and hits the
+// (project_id, trace_id) index.
+func (r *spanRepository) FindByTraceIds(ctx context.Context, refs []models.TraceRef) ([]models.Span, error) {
+	if len(refs) == 0 {
+		return []models.Span{}, nil
 	}
-	return spans, nil
+	projectIds, traceIds := shared.TraceRefIds(refs)
+	from, to := shared.TraceRefsWindowBounds(refs)
+	params := lit.P{"from": sqlitetypes.NewSQLiteTime(from), "to": sqlitetypes.NewSQLiteTime(to)}
+	query := `SELECT id, trace_id, project_id, name, start_time, duration, recorded_at, parent_span_id, attributes
+		FROM spans
+		WHERE project_id IN (` + shared.NamedIdList("pid", projectIds, params) + `)
+		AND trace_id IN (` + shared.NamedIdList("tid", traceIds, params) + `)
+		AND recorded_at >= :from AND recorded_at <= :to
+		ORDER BY start_time ASC`
+
+	rows, err := lit.SelectNamed[span](db.TelemetryDB, query, params)
+	if err != nil {
+		return nil, err
+	}
+	return shared.FilterSpansByTraceRefs(spansToModels(rows), refs), nil
 }
 
 var SpanRepository = &spanRepository{}

--- a/cli/cmd/traceway/traces.go
+++ b/cli/cmd/traceway/traces.go
@@ -71,7 +71,7 @@ func runTracesShow(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		_, _ = fmt.Fprintf(out, "DISTRIBUTED TRACE: %s\nNODES (%d):\n", resp.DistributedTraceId, len(resp.Nodes))
 		tw := output.NewTabWriter(out)
-		_, _ = fmt.Fprintln(tw, "PROJECT\tTYPE\tNAME\tERROR")
+		_, _ = fmt.Fprintln(tw, "PROJECT\tTYPE\tNAME\tSPANS\tERROR")
 		for _, n := range resp.Nodes {
 			name := "-"
 			switch {
@@ -86,7 +86,7 @@ func runTracesShow(cmd *cobra.Command, args []string) error {
 			if n.Exception != nil {
 				errCol = truncateHash(n.Exception.ExceptionHash, 12)
 			}
-			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", pickStr(n.ProjectName, "-"), n.TraceType, name, errCol)
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n", pickStr(n.ProjectName, "-"), n.TraceType, name, len(n.Spans), errCol)
 		}
 		return tw.Flush()
 	}

--- a/cli/test/contract/seed_test.go
+++ b/cli/test/contract/seed_test.go
@@ -108,9 +108,12 @@ func seedTelemetry(ctx context.Context, projectIDStr string, at time.Time) error
 		return fmt.Errorf("exception: %w", err)
 	}
 
+	// Spans are stored under their owning entity id as trace_id (the ingest
+	// re-roots them), so the seeded span belongs to the endpoint and surfaces in
+	// both the endpoint detail and the distributed trace.
 	span := models.Span{
 		Id:         seedSpanID,
-		TraceId:    seedTraceID,
+		TraceId:    seedEndpointID,
 		ProjectId:  pid,
 		Name:       "contract-span",
 		StartTime:  at,

--- a/cli/test/contract/testdata/distributed-trace.schema.txt
+++ b/cli/test/contract/testdata/distributed-trace.schema.txt
@@ -49,6 +49,13 @@ nodes[].exception.recordedAt: string
 nodes[].exception.stackTrace: string
 nodes[].projectId: string
 nodes[].projectName: string
+nodes[].spans[].duration: number
+nodes[].spans[].id: string
+nodes[].spans[].name: string
+nodes[].spans[].projectId: string
+nodes[].spans[].recordedAt: string
+nodes[].spans[].startTime: string
+nodes[].spans[].traceId: string
 nodes[].spans[]: empty
 nodes[].task.appVersion: string
 nodes[].task.attributes: null

--- a/cli/test/contract/testdata/endpoint-detail.schema.txt
+++ b/cli/test/contract/testdata/endpoint-detail.schema.txt
@@ -18,4 +18,10 @@ exception.recordedAt: string
 exception.stackTrace: string
 hasSpans: bool
 messages[]: empty
-spans[]: empty
+spans[].duration: number
+spans[].id: string
+spans[].name: string
+spans[].projectId: string
+spans[].recordedAt: string
+spans[].startTime: string
+spans[].traceId: string

--- a/frontend/src/lib/components/distributed-trace/distributed-trace-card.svelte
+++ b/frontend/src/lib/components/distributed-trace/distributed-trace-card.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { SvelteSet } from 'svelte/reactivity';
 	import { gotoHref } from '$lib/utils/navigation';
 	import { api } from '$lib/api';
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import { LoadingCircle } from '$lib/components/ui/loading-circle';
+	import SpanWaterfall from '$lib/components/spans/span-waterfall.svelte';
 	import { formatDuration, getStatusColor } from '$lib/utils/formatters';
-	import { ArrowRight, GitBranch } from '@lucide/svelte';
+	import { ArrowRight, ChevronDown, ChevronRight, GitBranch } from '@lucide/svelte';
 	import type {
 		DistributedTraceResponse,
 		DistributedTraceNode
@@ -38,6 +40,7 @@
 
 	let response = $state<DistributedTraceResponse | null>(null);
 	let loading = $state(true);
+	const expandedSpans = new SvelteSet<string>();
 
 	async function loadTrace() {
 		loading = true;
@@ -50,6 +53,26 @@
 			response = null;
 		} finally {
 			loading = false;
+		}
+	}
+
+	function nodeKey(node: DistributedTraceNode, index: number): string {
+		return node.endpoint?.id ?? node.task?.id ?? node.aiTrace?.id ?? `exception-${index}`;
+	}
+
+	function nodeDuration(node: DistributedTraceNode): number {
+		return node.endpoint?.duration ?? node.task?.duration ?? node.aiTrace?.duration ?? 0;
+	}
+
+	function nodeStartTime(node: DistributedTraceNode): string {
+		return node.endpoint?.recordedAt ?? node.task?.recordedAt ?? node.aiTrace?.recordedAt ?? '';
+	}
+
+	function toggleSpans(key: string) {
+		if (expandedSpans.has(key)) {
+			expandedSpans.delete(key);
+		} else {
+			expandedSpans.add(key);
 		}
 	}
 
@@ -103,53 +126,80 @@
 		</Card.Header>
 		<Card.Content>
 			<div class="space-y-3">
-				{#each response.nodes as node, i (i)}
-					<div class="flex items-center gap-3 rounded-md border p-3 {i > 0 ? 'ml-6' : ''}">
-						<div class="flex min-w-0 flex-1 items-center gap-3">
-							<Badge variant="outline" class="shrink-0">{node.projectName}</Badge>
-							<span class="truncate font-mono text-sm">
-								{#if node.traceType === 'task'}
-									{node.task?.taskName}
-								{:else if node.traceType === 'ai_trace'}
-									{node.aiTrace?.traceName}
-								{:else if node.traceType === 'exception'}
-									{node.exception?.stackTrace.split('\n')[0]}
-								{:else}
-									{node.endpoint?.endpoint}
+				{#each response.nodes as node, i (nodeKey(node, i))}
+					{@const key = nodeKey(node, i)}
+					{@const spanCount = node.spans?.length ?? 0}
+					<div class={i > 0 ? 'ml-6' : ''}>
+						<div class="flex items-center gap-3 rounded-md border p-3">
+							<div class="flex min-w-0 flex-1 items-center gap-3">
+								<Badge variant="outline" class="shrink-0">{node.projectName}</Badge>
+								<span class="truncate font-mono text-sm">
+									{#if node.traceType === 'task'}
+										{node.task?.taskName}
+									{:else if node.traceType === 'ai_trace'}
+										{node.aiTrace?.traceName}
+									{:else if node.traceType === 'exception'}
+										{node.exception?.stackTrace.split('\n')[0]}
+									{:else}
+										{node.endpoint?.endpoint}
+									{/if}
+								</span>
+								{#if node.traceType === 'endpoint' && node.endpoint}
+									<span
+										class="shrink-0 font-mono text-sm {getStatusColor(node.endpoint.statusCode)}"
+									>
+										{node.endpoint.statusCode}
+									</span>
 								{/if}
-							</span>
-							{#if node.traceType === 'endpoint' && node.endpoint}
-								<span class="shrink-0 font-mono text-sm {getStatusColor(node.endpoint.statusCode)}">
-									{node.endpoint.statusCode}
-								</span>
-							{/if}
-							{#if node.traceType === 'ai_trace' && node.aiTrace}
-								<Badge variant="secondary" class="shrink-0"
-									>{node.aiTrace.provider || node.aiTrace.model || 'AI'}</Badge
+								{#if node.traceType === 'ai_trace' && node.aiTrace}
+									<Badge variant="secondary" class="shrink-0"
+										>{node.aiTrace.provider || node.aiTrace.model || 'AI'}</Badge
+									>
+								{/if}
+								{#if node.traceType !== 'exception'}
+									<span class="shrink-0 font-mono text-sm text-muted-foreground">
+										{formatDuration(nodeDuration(node))}
+									</span>
+								{/if}
+								{#if node.exception}
+									<Badge variant="destructive" class="shrink-0">Exception</Badge>
+								{/if}
+							</div>
+							{#if spanCount > 0}
+								<Button
+									variant="ghost"
+									size="sm"
+									class="shrink-0 text-muted-foreground"
+									onclick={() => toggleSpans(key)}
+									aria-expanded={expandedSpans.has(key)}
 								>
+									{#if expandedSpans.has(key)}
+										<ChevronDown class="mr-1 h-3 w-3" />
+									{:else}
+										<ChevronRight class="mr-1 h-3 w-3" />
+									{/if}
+									{spanCount}
+									{spanCount === 1 ? 'span' : 'spans'}
+								</Button>
 							{/if}
-							{#if node.traceType !== 'exception'}
-								<span class="shrink-0 font-mono text-sm text-muted-foreground">
-									{formatDuration(
-										node.traceType === 'task'
-											? (node.task?.duration ?? 0)
-											: node.traceType === 'ai_trace'
-												? (node.aiTrace?.duration ?? 0)
-												: (node.endpoint?.duration ?? 0)
-									)}
-								</span>
-							{/if}
-							{#if node.exception}
-								<Badge variant="destructive" class="shrink-0">Exception</Badge>
+							{#if isCurrentNode(node)}
+								<Badge class="bg-blue-500 text-white hover:bg-blue-500">You're here</Badge>
+							{:else}
+								<Button variant="ghost" size="sm" onclick={() => navigateToNode(node)}>
+									View
+									<ArrowRight class="ml-1 h-3 w-3" />
+								</Button>
 							{/if}
 						</div>
-						{#if isCurrentNode(node)}
-							<Badge class="bg-blue-500 text-white hover:bg-blue-500">You're here</Badge>
-						{:else}
-							<Button variant="ghost" size="sm" onclick={() => navigateToNode(node)}>
-								View
-								<ArrowRight class="ml-1 h-3 w-3" />
-							</Button>
+						{#if spanCount > 0 && expandedSpans.has(key)}
+							<div class="mt-2 rounded-md border p-2">
+								<SpanWaterfall
+									spans={node.spans}
+									traceDuration={nodeDuration(node)}
+									traceStartTime={nodeStartTime(node)}
+									rootSpanId={node.endpoint?.spanId ?? node.task?.spanId}
+								/>
+							</div>
 						{/if}
 					</div>
 				{/each}

--- a/frontend/src/lib/types/distributed-trace.ts
+++ b/frontend/src/lib/types/distributed-trace.ts
@@ -8,12 +8,14 @@ export type DistributedTraceNode = {
 		duration: number;
 		statusCode: number;
 		recordedAt: string;
+		spanId?: string;
 	};
 	task?: {
 		id: string;
 		taskName: string;
 		duration: number;
 		recordedAt: string;
+		spanId?: string;
 	};
 	aiTrace?: {
 		id: string;


### PR DESCRIPTION
Closes #352

## Problem

`GetDistributedTrace` initialised every node with `Spans: []models.Span{}` and never queried the spans table. The dashboard's Distributed Trace card, `traceway traces show`, and the MCP `get_trace` tool therefore reported zero spans for every service in a trace, even though the response model, the CLI client type and the docs all describe nodes carrying their spans.

## Fix

Spans are stored under their owning endpoint / task / AI-trace id as `trace_id` (the ingest re-roots them), which is exactly what the detail pages read via `SpanRepository.FindByTraceId`. The handler now:

- collects one `models.TraceRef{ProjectId, TraceId, RecordedAt}` per entity node,
- loads all of them with a single `SpanRepository.FindByTraceIds` query, implemented on the SQLite, DuckDB and ClickHouse backends. The query is bounded to the usual ±24h trace window stretched across the earliest and latest node, uses the `(project_id, trace_id)` index / ordering key, and is filtered back to the exact `(project, trace)` pairs so the two `IN` lists' cross product cannot leak a same-id span from a project that did not reference it,
- attaches the results per node. Exception-only nodes keep an empty list, and `spans` is never `null`.

Spans stored under the OTel trace id itself (the orphan path, when no owner was found in the batch) belong to no node and are still not surfaced, same as today.

## Also in this PR

- **CLI contract seed**: the seeded span was keyed by the distributed trace id (the orphan path). It now belongs to the seeded endpoint, so the `endpoint-detail` and `distributed-trace` goldens gain the `spans[].*` shape lines (regenerated with `-update`).
- **CLI**: `traceway traces show` prints a `SPANS` column.
- **Frontend**: the Distributed Trace card shows an `N spans` toggle per node that expands into that node's `SpanWaterfall`, reusing the endpoint page's component.

## Verification

- New tests: `shared` helper unit tests, `TestSpanRepository_FindByTraceIds` (+ empty) on SQLite and DuckDB, and a handler test `TestGetDistributedTraceAttachesSpansToOwningNodes` that fails on `main` (`endpoint spans = [], want both owned spans`).
- `go build` under all three tag sets; `go test` for `controllers`, `repositories/telemetry/...`, `models`; `cd cli && just test lint gen-skills-check contract-test` all green; `npm run check` / `npm run lint` clean.
- Live run: booted the backend on SQLite, ingested an OTLP/JSON trace with a `checkout-api` SERVER span (two child spans) and an `email-worker` CONSUMER span (two child spans) under one trace id, then opened the endpoint page in headless Chromium. The API returned 2 spans on the endpoint node and 2 on the task node, and the card rendered a `2 spans` toggle for each that expands into the waterfall with the ingested span names and durations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
