### PR TITLE
Appended ago text to time when the issue was last seen.

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -878,7 +878,7 @@ service:
 											{issue.count}
 										</Table.Cell>
 										<Table.Cell class="py-3 text-right text-sm text-muted-foreground tabular-nums">
-											{formatRelativeTime(issue.lastSeen, timezone)}
+											{formatRelativeTime(issue.lastSeen, timezone)} ago
 										</Table.Cell>
 									</Table.Row>
 								{/each}


### PR DESCRIPTION
<img width="775" height="225" alt="Screenshot 2026-09-09 at 11 37 05" src="https://github.com/user-attachments/assets/4deac352-769c-45ec-a62a-87463d5faa3a" />
This is new state on the image above.

Added 'ago' word. This is on the dashboard page.